### PR TITLE
JToken serializer fails when encountering a Uri within a JObject

### DIFF
--- a/src/Serialization/Neuroglia.Serialization.YamlDotNet/Converters/JTokenSerializer.cs
+++ b/src/Serialization/Neuroglia.Serialization.YamlDotNet/Converters/JTokenSerializer.cs
@@ -70,6 +70,7 @@ namespace YamlDotNet.Serialization
                     {
                         JTokenType.Boolean => new(token.ToString().ToLower()),
                         JTokenType.TimeSpan => new(Iso8601TimeSpan.Format(token.ToObject<TimeSpan>())),
+                        JTokenType.Uri => new(token.Value<Uri>().OriginalString),
                         _ => new(AnchorName.Empty, TagName.Empty, token.Value<string>(), ScalarStyle.SingleQuoted, true, true),
                     };
                     emitter.Emit(scalar);

--- a/test/Neuroglia.UnitTests/Cases/Serialization/YamlDotNetSerializerTests.cs
+++ b/test/Neuroglia.UnitTests/Cases/Serialization/YamlDotNetSerializerTests.cs
@@ -70,7 +70,12 @@ namespace Neuroglia.UnitTests.Cases.Serialization
         public async Task SerializeAndDeserialize_JObject_ShouldWork()
         {
             //arrange
-            var toSerialize = JObject.FromObject(new { FirstName = "Fake First Name", LastName = "Fake Last Name" });
+            var toSerialize = JObject.FromObject(new 
+            {
+                FirstName = "Fake First Name", 
+                LastName = "Fake Last Name",
+                UriProperty = new Uri("#/definitions/SchemaDefinitionPointer", UriKind.RelativeOrAbsolute)
+            });
 
             //act
             var yaml = await this.Serializer.SerializeAsync(toSerialize);


### PR DESCRIPTION
When serializing a JObject which has come from the AsyncApi document which contains a "definitions" property, the Serialization fails when using with NewtonsoftJson.

This occurs when attempting to serialize an AsyncApi document that contains schema definition pointers.

Possibly related: https://github.com/neuroglia-io/AsyncApi/issues/8

Below is a screenshot of the trapped error, where we can see the token type is a URI, and token name is "#/definitions/ClassificationForm" <- ClassificationForm is a type in my lib. The issue isn't with that property, the issue is the pointer is a relative URI within the JsonSchema.

I've updated the test was that was passing, to fail, without the below changes.

![image](https://user-images.githubusercontent.com/3226335/150155498-7b3c27ac-fe46-4b46-94db-2317c0963689.png)

@cdavernas 