### PR TITLE
Redux DevTools Middleware: late state

### DIFF
--- a/src/Data/Neuroglia.Data.Flux.ReduxDevTools/Services/ReduxDevToolsMiddleware.cs
+++ b/src/Data/Neuroglia.Data.Flux.ReduxDevTools/Services/ReduxDevToolsMiddleware.cs
@@ -61,7 +61,7 @@ namespace Neuroglia.Data.Flux
             if(context == null)
                 throw new ArgumentNullException(nameof(context));
             var result = await this.Next.Invoke(context);
-            await this.ReduxDevToolsPlugin.DispatchAsync(context.Action, context.Store.State);
+            await this.ReduxDevToolsPlugin.DispatchAsync(context.Action, result);
             return result;
         }
 


### PR DESCRIPTION
The DevTools middleware was tracking the previous (old) state instead of the current (new) state, making it one step late.