### PR TITLE
Critical fix to the JQExpressionEvaluator

### DIFF
--- a/src/AspNetCore/Neuroglia.AspNetCore.JsonPatch/Neuroglia.AspNetCore.JsonPatch.csproj
+++ b/src/AspNetCore/Neuroglia.AspNetCore.JsonPatch/Neuroglia.AspNetCore.JsonPatch.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia aspnet core json patch</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/AspNetCore/Neuroglia.AspNetCore/Neuroglia.AspNetCore.csproj
+++ b/src/AspNetCore/Neuroglia.AspNetCore/Neuroglia.AspNetCore.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework asp core</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Caching/Neuroglia.Caching.Abstractions/Neuroglia.Caching.Abstractions.csproj
+++ b/src/Caching/Neuroglia.Caching.Abstractions/Neuroglia.Caching.Abstractions.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia caching abstractions</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Caching/Neuroglia.Caching.InMemory/Neuroglia.Caching.InMemory.csproj
+++ b/src/Caching/Neuroglia.Caching.InMemory/Neuroglia.Caching.InMemory.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia caching memory</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Caching/Neuroglia.Caching.Redis/Neuroglia.Caching.Redis.csproj
+++ b/src/Caching/Neuroglia.Caching.Redis/Neuroglia.Caching.Redis.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia caching redis</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Core/Neuroglia.Core/Neuroglia.Core.csproj
+++ b/src/Core/Neuroglia.Core/Neuroglia.Core.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework core</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Csv/Neuroglia.Data.Csv.csproj
+++ b/src/Data/Neuroglia.Data.Csv/Neuroglia.Data.Csv.csproj
@@ -9,9 +9,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data csv</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.DistributedCache/Neuroglia.Data.DistributedCache.csproj
+++ b/src/Data/Neuroglia.Data.DistributedCache/Neuroglia.Data.DistributedCache.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data entity ef</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.EntityFrameworkCore/Neuroglia.Data.EntityFrameworkCore.csproj
+++ b/src/Data/Neuroglia.Data.EntityFrameworkCore/Neuroglia.Data.EntityFrameworkCore.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data entity ef</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.EventSourcing.EventStore/Neuroglia.Data.EventSourcing.EventStore.csproj
+++ b/src/Data/Neuroglia.Data.EventSourcing.EventStore/Neuroglia.Data.EventSourcing.EventStore.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data event sourcing eventstore es</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.EventSourcing/Neuroglia.Data.EventSourcing.csproj
+++ b/src/Data/Neuroglia.Data.EventSourcing/Neuroglia.Data.EventSourcing.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data event sourcing</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.csproj
+++ b/src/Data/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data expressions jq</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Expressions/Neuroglia.Data.Expressions.csproj
+++ b/src/Data/Neuroglia.Data.Expressions/Neuroglia.Data.Expressions.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data expression</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Flux.ReduxDevTools/Neuroglia.Data.Flux.ReduxDevTools.csproj
+++ b/src/Data/Neuroglia.Data.Flux.ReduxDevTools/Neuroglia.Data.Flux.ReduxDevTools.csproj
@@ -9,9 +9,9 @@
 	<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PackageTags>neuroglia framework data flux redux dev tools</PackageTags>
-	<Version>2.0.1.61</Version>
-	<AssemblyVersion>2.0.1.61</AssemblyVersion>
-	<FileVersion>2.0.1.61</FileVersion>
+	<Version>2.0.1.62</Version>
+	<AssemblyVersion>2.0.1.62</AssemblyVersion>
+	<FileVersion>2.0.1.62</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Flux/Neuroglia.Data.Flux.csproj
+++ b/src/Data/Neuroglia.Data.Flux/Neuroglia.Data.Flux.csproj
@@ -8,9 +8,9 @@
 	<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PackageTags>neuroglia framework data flux</PackageTags>
-	<Version>2.0.1.61</Version>
-	<AssemblyVersion>2.0.1.61</AssemblyVersion>
-	<FileVersion>2.0.1.61</FileVersion>
+	<Version>2.0.1.62</Version>
+	<AssemblyVersion>2.0.1.62</AssemblyVersion>
+	<FileVersion>2.0.1.62</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Kubernetes/Neuroglia.Data.Kubernetes.csproj
+++ b/src/Data/Neuroglia.Data.Kubernetes/Neuroglia.Data.Kubernetes.csproj
@@ -10,9 +10,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data kubernetes k8s</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Data/Neuroglia.Data.MongoDB/Neuroglia.Data.MongoDB.csproj
+++ b/src/Data/Neuroglia.Data.MongoDB/Neuroglia.Data.MongoDB.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data mongo mongodb</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.OData/Neuroglia.Data.OData.csproj
+++ b/src/Data/Neuroglia.Data.OData/Neuroglia.Data.OData.csproj
@@ -9,9 +9,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data odata</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data/Neuroglia.Data.csproj
+++ b/src/Data/Neuroglia.Data/Neuroglia.Data.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Eventing/Neuroglia.Eventing.CloudEvents.AspNetCore/Neuroglia.Eventing.CloudEvents.AspNetCore.csproj
+++ b/src/Eventing/Neuroglia.Eventing.CloudEvents.AspNetCore/Neuroglia.Eventing.CloudEvents.AspNetCore.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework cloudevent asp core</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Eventing/Neuroglia.Eventing.CloudEvents/Neuroglia.Eventing.CloudEvents.csproj
+++ b/src/Eventing/Neuroglia.Eventing.CloudEvents/Neuroglia.Eventing.CloudEvents.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework cloudevent</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mapping/Neuroglia.Mapping/Neuroglia.Mapping.csproj
+++ b/src/Mapping/Neuroglia.Mapping/Neuroglia.Mapping.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mapping</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation.AspNetCore/Neuroglia.Mediation.AspNetCore.csproj
+++ b/src/Mediation/Neuroglia.Mediation.AspNetCore/Neuroglia.Mediation.AspNetCore.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mediation asp core</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation.Extensions.OpenTelemetry/Neuroglia.Mediation.Extensions.OpenTelemetry.csproj
+++ b/src/Mediation/Neuroglia.Mediation.Extensions.OpenTelemetry/Neuroglia.Mediation.Extensions.OpenTelemetry.csproj
@@ -9,9 +9,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework mediation opentelemetry instrumentation</PackageTags>
-		<Version>2.0.1.61</Version>
-		<AssemblyVersion>2.0.1.61</AssemblyVersion>
-		<FileVersion>2.0.1.61</FileVersion>
+		<Version>2.0.1.62</Version>
+		<AssemblyVersion>2.0.1.62</AssemblyVersion>
+		<FileVersion>2.0.1.62</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
+++ b/src/Mediation/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mediation fluent validation</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation/Neuroglia.Mediation.csproj
+++ b/src/Mediation/Neuroglia.Mediation/Neuroglia.Mediation.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mediation</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Abstractions/Neuroglia.Serialization.Abstractions.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Abstractions/Neuroglia.Serialization.Abstractions.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization abstraction</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Avro/Neuroglia.Serialization.Avro.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Avro/Neuroglia.Serialization.Avro.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization avro</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Dynamic/Neuroglia.Serialization.Dynamic.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Dynamic/Neuroglia.Serialization.Dynamic.csproj
@@ -10,8 +10,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization dynamic</PackageTags>
     <Version>2.0.1.6</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Json/Neuroglia.Serialization.Json.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Json/Neuroglia.Serialization.Json.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization json</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.NewtonsoftJson/Neuroglia.Serialization.NewtonsoftJson.csproj
+++ b/src/Serialization/Neuroglia.Serialization.NewtonsoftJson/Neuroglia.Serialization.NewtonsoftJson.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization newtonsoft json</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Protobuf/Neuroglia.Serialization.Protobuf.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Protobuf/Neuroglia.Serialization.Protobuf.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization protobuf</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.YamlDotNet/Neuroglia.Serialization.YamlDotNet.csproj
+++ b/src/Serialization/Neuroglia.Serialization.YamlDotNet/Neuroglia.Serialization.YamlDotNet.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization yaml dotnet</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Templating/Neuroglia.Templating.Abstractions/Neuroglia.Templating.Abstractions.csproj
+++ b/src/Templating/Neuroglia.Templating.Abstractions/Neuroglia.Templating.Abstractions.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework templating abstractions</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Templating/Neuroglia.Templating.RazorLight/Neuroglia.Templating.RazorLight.csproj
+++ b/src/Templating/Neuroglia.Templating.RazorLight/Neuroglia.Templating.RazorLight.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework templating razor</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Testing/Neuroglia.AspNetCore.Mvc.Testing/Neuroglia.AspNetCore.Mvc.Testing.csproj
+++ b/src/Testing/Neuroglia.AspNetCore.Mvc.Testing/Neuroglia.AspNetCore.Mvc.Testing.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework asp mvc testing</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Testing/Neuroglia.Xunit/Neuroglia.Xunit.csproj
+++ b/src/Testing/Neuroglia.Xunit/Neuroglia.Xunit.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework xunit testing</PackageTags>
-    <Version>2.0.1.61</Version>
-    <AssemblyVersion>2.0.1.61</AssemblyVersion>
-    <FileVersion>2.0.1.61</FileVersion>
+    <Version>2.0.1.62</Version>
+    <AssemblyVersion>2.0.1.62</AssemblyVersion>
+    <FileVersion>2.0.1.62</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Critical fix to the JQExpressionEvaluator, which was encoutering shell args length limitations, especially on Windows systems where the limit is stupidly low