### PR TITLE
fix(Dagre): prevented event callbacks stackup

### DIFF
--- a/src/AspNetCore/Neuroglia.AspNetCore.JsonPatch/Neuroglia.AspNetCore.JsonPatch.csproj
+++ b/src/AspNetCore/Neuroglia.AspNetCore.JsonPatch/Neuroglia.AspNetCore.JsonPatch.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia aspnet core json patch</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/AspNetCore/Neuroglia.AspNetCore/Neuroglia.AspNetCore.csproj
+++ b/src/AspNetCore/Neuroglia.AspNetCore/Neuroglia.AspNetCore.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework asp core</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Blazor/Neuroglia.Blazor.Dagre/DagreGraph.razor
+++ b/src/Blazor/Neuroglia.Blazor.Dagre/DagreGraph.razor
@@ -93,12 +93,12 @@
         if (this.Graph != null)
         {
             this.RemoveHandlers();
-            this.Graph.MouseEnter += this.OnMouseEnter.InvokeAsync;
-            this.Graph.MouseLeave += this.OnMouseLeave.InvokeAsync;
-            this.Graph.MouseDown += this.OnMouseDown.InvokeAsync;
-            this.Graph.MouseUp += this.OnMouseUp.InvokeAsync;
-            this.Graph.MouseMove += this.OnMouseMove.InvokeAsync;
-            this.Graph.Wheel += this.OnWheel.InvokeAsync;
+            this.Graph.MouseEnter += this.InvokeMouseEnter;
+            this.Graph.MouseLeave += this.InvokeMouseLeave;
+            this.Graph.MouseDown += this.InvokeMouseDown;
+            this.Graph.MouseUp += this.InvokeMouseUp;
+            this.Graph.MouseMove += this.InvokeMouseMove;
+            this.Graph.Wheel += this.InvokeWheel;
             //this.Graph.ShowConstruction = true;
             await this.RefreshAsync();
             //Console.WriteLine(await this.DagreService.SerializeAsync(this.Graph.DagreGraph!));
@@ -106,16 +106,46 @@
         }
     }
 
+    protected async Task InvokeMouseEnter(GraphEventArgs<MouseEventArgs> e)
+    {
+        await this.OnMouseEnter.InvokeAsync(e);
+    }
+
+    protected async Task InvokeMouseLeave(GraphEventArgs<MouseEventArgs> e)
+    {
+        await this.OnMouseLeave.InvokeAsync(e);
+    }
+
+    protected async Task InvokeMouseDown(GraphEventArgs<MouseEventArgs> e)
+    {
+        await this.OnMouseDown.InvokeAsync(e);
+    }
+
+    protected async Task InvokeMouseUp(GraphEventArgs<MouseEventArgs> e)
+    {
+        await this.OnMouseUp.InvokeAsync(e);
+    }
+
+    protected async Task InvokeMouseMove(GraphEventArgs<MouseEventArgs> e)
+    {
+        await this.OnMouseMove.InvokeAsync(e);
+    }
+
+    protected async Task InvokeWheel(GraphEventArgs<WheelEventArgs> e)
+    {
+        await this.OnWheel.InvokeAsync(e);
+    }
+
     protected virtual void RemoveHandlers()
     {
         if (this.Graph != null)
         {
-            this.Graph.MouseEnter -= this.OnMouseEnter.InvokeAsync;
-            this.Graph.MouseLeave -= this.OnMouseLeave.InvokeAsync;
-            this.Graph.MouseDown -= this.OnMouseDown.InvokeAsync;
-            this.Graph.MouseUp -= this.OnMouseUp.InvokeAsync;
-            this.Graph.MouseMove -= this.OnMouseMove.InvokeAsync;
-            this.Graph.Wheel -= this.OnWheel.InvokeAsync;
+            this.Graph.MouseEnter -= this.InvokeMouseEnter;
+            this.Graph.MouseLeave -= this.InvokeMouseLeave;
+            this.Graph.MouseDown -= this.InvokeMouseDown;
+            this.Graph.MouseUp -= this.InvokeMouseUp;
+            this.Graph.MouseMove -= this.InvokeMouseMove;
+            this.Graph.Wheel -= this.InvokeWheel;
         }
     }
 

--- a/src/Blazor/Neuroglia.Blazor.Dagre/Neuroglia.Blazor.Dagre.csproj
+++ b/src/Blazor/Neuroglia.Blazor.Dagre/Neuroglia.Blazor.Dagre.csproj
@@ -11,9 +11,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework blazor dagre diagram graph</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Caching/Neuroglia.Caching.Abstractions/Neuroglia.Caching.Abstractions.csproj
+++ b/src/Caching/Neuroglia.Caching.Abstractions/Neuroglia.Caching.Abstractions.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia caching abstractions</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Caching/Neuroglia.Caching.InMemory/Neuroglia.Caching.InMemory.csproj
+++ b/src/Caching/Neuroglia.Caching.InMemory/Neuroglia.Caching.InMemory.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia caching memory</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Caching/Neuroglia.Caching.Redis/Neuroglia.Caching.Redis.csproj
+++ b/src/Caching/Neuroglia.Caching.Redis/Neuroglia.Caching.Redis.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia caching redis</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Core/Neuroglia.Core/Neuroglia.Core.csproj
+++ b/src/Core/Neuroglia.Core/Neuroglia.Core.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework core</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Csv/Neuroglia.Data.Csv.csproj
+++ b/src/Data/Neuroglia.Data.Csv/Neuroglia.Data.Csv.csproj
@@ -9,9 +9,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data csv</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.DistributedCache/Neuroglia.Data.DistributedCache.csproj
+++ b/src/Data/Neuroglia.Data.DistributedCache/Neuroglia.Data.DistributedCache.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data entity ef</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.EntityFrameworkCore/Neuroglia.Data.EntityFrameworkCore.csproj
+++ b/src/Data/Neuroglia.Data.EntityFrameworkCore/Neuroglia.Data.EntityFrameworkCore.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data entity ef</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.EventSourcing.EventStore/Neuroglia.Data.EventSourcing.EventStore.csproj
+++ b/src/Data/Neuroglia.Data.EventSourcing.EventStore/Neuroglia.Data.EventSourcing.EventStore.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data event sourcing eventstore es</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.EventSourcing/Neuroglia.Data.EventSourcing.csproj
+++ b/src/Data/Neuroglia.Data.EventSourcing/Neuroglia.Data.EventSourcing.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data event sourcing</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.csproj
+++ b/src/Data/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data expressions jq</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Expressions/Neuroglia.Data.Expressions.csproj
+++ b/src/Data/Neuroglia.Data.Expressions/Neuroglia.Data.Expressions.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data expression</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Flux.ReduxDevTools/Neuroglia.Data.Flux.ReduxDevTools.csproj
+++ b/src/Data/Neuroglia.Data.Flux.ReduxDevTools/Neuroglia.Data.Flux.ReduxDevTools.csproj
@@ -9,9 +9,9 @@
 	<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PackageTags>neuroglia framework data flux redux dev tools</PackageTags>
-	<Version>2.0.1.75</Version>
-	<AssemblyVersion>2.0.1.75</AssemblyVersion>
-	<FileVersion>2.0.1.75</FileVersion>
+	<Version>2.0.1.76</Version>
+	<AssemblyVersion>2.0.1.76</AssemblyVersion>
+	<FileVersion>2.0.1.76</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Flux/Neuroglia.Data.Flux.csproj
+++ b/src/Data/Neuroglia.Data.Flux/Neuroglia.Data.Flux.csproj
@@ -8,9 +8,9 @@
 	<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PackageTags>neuroglia framework data flux</PackageTags>
-	<Version>2.0.1.75</Version>
-	<AssemblyVersion>2.0.1.75</AssemblyVersion>
-	<FileVersion>2.0.1.75</FileVersion>
+	<Version>2.0.1.76</Version>
+	<AssemblyVersion>2.0.1.76</AssemblyVersion>
+	<FileVersion>2.0.1.76</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.Kubernetes/Neuroglia.Data.Kubernetes.csproj
+++ b/src/Data/Neuroglia.Data.Kubernetes/Neuroglia.Data.Kubernetes.csproj
@@ -10,9 +10,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data kubernetes k8s</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Data/Neuroglia.Data.MongoDB/Neuroglia.Data.MongoDB.csproj
+++ b/src/Data/Neuroglia.Data.MongoDB/Neuroglia.Data.MongoDB.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data mongo mongodb</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.OData/Neuroglia.Data.OData.csproj
+++ b/src/Data/Neuroglia.Data.OData/Neuroglia.Data.OData.csproj
@@ -9,9 +9,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework data odata</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data.SchemaRegistry.ApiCurio/Neuroglia.Data.SchemaRegistry.ApiCurio.csproj
+++ b/src/Data/Neuroglia.Data.SchemaRegistry.ApiCurio/Neuroglia.Data.SchemaRegistry.ApiCurio.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data schema registry apicurio</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Data/Neuroglia.Data/Neuroglia.Data.csproj
+++ b/src/Data/Neuroglia.Data/Neuroglia.Data.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework data</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Eventing/Neuroglia.Eventing.CloudEvents.AspNetCore/Neuroglia.Eventing.CloudEvents.AspNetCore.csproj
+++ b/src/Eventing/Neuroglia.Eventing.CloudEvents.AspNetCore/Neuroglia.Eventing.CloudEvents.AspNetCore.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework cloudevent asp core</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Eventing/Neuroglia.Eventing.CloudEvents/Neuroglia.Eventing.CloudEvents.csproj
+++ b/src/Eventing/Neuroglia.Eventing.CloudEvents/Neuroglia.Eventing.CloudEvents.csproj
@@ -8,9 +8,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework cloudevent</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mapping/Neuroglia.Mapping/Neuroglia.Mapping.csproj
+++ b/src/Mapping/Neuroglia.Mapping/Neuroglia.Mapping.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mapping</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation.AspNetCore/Neuroglia.Mediation.AspNetCore.csproj
+++ b/src/Mediation/Neuroglia.Mediation.AspNetCore/Neuroglia.Mediation.AspNetCore.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mediation asp core</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation.Extensions.OpenTelemetry/Neuroglia.Mediation.Extensions.OpenTelemetry.csproj
+++ b/src/Mediation/Neuroglia.Mediation.Extensions.OpenTelemetry/Neuroglia.Mediation.Extensions.OpenTelemetry.csproj
@@ -9,9 +9,9 @@
 		<RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>neuroglia framework mediation opentelemetry instrumentation</PackageTags>
-		<Version>2.0.1.75</Version>
-		<AssemblyVersion>2.0.1.75</AssemblyVersion>
-		<FileVersion>2.0.1.75</FileVersion>
+		<Version>2.0.1.76</Version>
+		<AssemblyVersion>2.0.1.76</AssemblyVersion>
+		<FileVersion>2.0.1.76</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
+++ b/src/Mediation/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mediation fluent validation</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Mediation/Neuroglia.Mediation/Neuroglia.Mediation.csproj
+++ b/src/Mediation/Neuroglia.Mediation/Neuroglia.Mediation.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework mediation</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Abstractions/Neuroglia.Serialization.Abstractions.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Abstractions/Neuroglia.Serialization.Abstractions.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization abstraction</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Avro/Neuroglia.Serialization.Avro.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Avro/Neuroglia.Serialization.Avro.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization avro</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Dynamic/Neuroglia.Serialization.Dynamic.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Dynamic/Neuroglia.Serialization.Dynamic.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization dynamic</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Json/Neuroglia.Serialization.Json.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Json/Neuroglia.Serialization.Json.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization json</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.NewtonsoftJson/Neuroglia.Serialization.NewtonsoftJson.csproj
+++ b/src/Serialization/Neuroglia.Serialization.NewtonsoftJson/Neuroglia.Serialization.NewtonsoftJson.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization newtonsoft json</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.Protobuf/Neuroglia.Serialization.Protobuf.csproj
+++ b/src/Serialization/Neuroglia.Serialization.Protobuf/Neuroglia.Serialization.Protobuf.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization protobuf</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Serialization/Neuroglia.Serialization.YamlDotNet/Neuroglia.Serialization.YamlDotNet.csproj
+++ b/src/Serialization/Neuroglia.Serialization.YamlDotNet/Neuroglia.Serialization.YamlDotNet.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework serialization yaml dotnet</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Templating/Neuroglia.Templating.Abstractions/Neuroglia.Templating.Abstractions.csproj
+++ b/src/Templating/Neuroglia.Templating.Abstractions/Neuroglia.Templating.Abstractions.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework templating abstractions</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Templating/Neuroglia.Templating.RazorLight/Neuroglia.Templating.RazorLight.csproj
+++ b/src/Templating/Neuroglia.Templating.RazorLight/Neuroglia.Templating.RazorLight.csproj
@@ -10,9 +10,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework templating razor</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Testing/Neuroglia.AspNetCore.Mvc.Testing/Neuroglia.AspNetCore.Mvc.Testing.csproj
+++ b/src/Testing/Neuroglia.AspNetCore.Mvc.Testing/Neuroglia.AspNetCore.Mvc.Testing.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework asp mvc testing</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Testing/Neuroglia.Xunit/Neuroglia.Xunit.csproj
+++ b/src/Testing/Neuroglia.Xunit/Neuroglia.Xunit.csproj
@@ -8,9 +8,9 @@
     <RepositoryUrl>https://github.com/neuroglia-io/framework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>neuroglia framework xunit testing</PackageTags>
-    <Version>2.0.1.75</Version>
-    <AssemblyVersion>2.0.1.75</AssemblyVersion>
-    <FileVersion>2.0.1.75</FileVersion>
+    <Version>2.0.1.76</Version>
+    <AssemblyVersion>2.0.1.76</AssemblyVersion>
+    <FileVersion>2.0.1.76</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
I discovered `EventCallback`s are reset with each render and trigger a render themselves (see: https://github.com/dotnet/aspnetcore/issues/18279 ).

Theoretically, the EventCallbacks were removed and readded to the list of event handlers of  the `IGraphViewModel` in `DagreGraph.OnParametersSetAsync` so when an event was triggered by the graph, the associated EventHandler of the component would also be triggered. But, as the `EventCallback` is replaced with each render, removing a "new/unknown" `EventCallback` didn't have any effect, resulting in stacking the "new" `EventCallback` with the "old" ones already bound to `IGraphViewModel` event handlers.

This issue has been fixed by creating a method that will invoke the associated `EventCallback`. That method can safely be removed and readded without creating the unwanted side effect mentioned above.

Notes: updated to v2.0.1.76