### PR TITLE
Extended property change support in Neuroglia.Blazor.Dagre

### DIFF
--- a/src/Blazor/Neuroglia.Blazor.Dagre/Models/GraphElement.cs
+++ b/src/Blazor/Neuroglia.Blazor.Dagre/Models/GraphElement.cs
@@ -9,39 +9,103 @@
         /// <inheritdoc />
         public virtual Guid Id { get; set; } = Guid.NewGuid();
 
+        /// <summary>
+        /// Stores the element's label
+        /// </summary>
+        protected string? _label;
         /// <inheritdoc />
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public virtual string? Label { get; set; }
+        public virtual string? Label
+        {
+            get => this._label;
+            set
+            {
+                this._label = value;
+                this.OnChange();
+            }
+        }
 
+        /// <summary>
+        /// Stores the element's component type
+        /// </summary>
+        protected Type? _componentType;
         /// <inheritdoc />
         [System.Text.Json.Serialization.JsonIgnore]
         [Newtonsoft.Json.JsonIgnore]
-        public virtual Type? ComponentType { get; set; }
+        public virtual Type? ComponentType
+        {
+            get => this._componentType;
+            set
+            {
+                this._componentType = value;
+                this.OnChange();
+            }
+        }
 
+        /// <summary>
+        /// Stores the element's css class
+        /// </summary>
+        protected string? _cssClass;
         /// <inheritdoc />
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public virtual string? CssClass { get; set; }
+        public virtual string? CssClass
+        {
+            get => this._cssClass;
+            set
+            {
+                this._cssClass = value;
+                this.OnChange();
+            }
+        }
 
+
+        /// <summary>
+        /// Stores the element's metadata
+        /// </summary>
+        protected IDictionary<string, object>? _metadata = null;
         /// <inheritdoc />
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonExtensionData]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonExtensionData]
-        public virtual IDictionary<string, object>? Metadata { get; set; }
+        public virtual IDictionary<string, object>? Metadata
+        {
+            get => this._metadata;
+            set
+            {
+                this._metadata = value;
+                this.OnChange();
+            }
+        }
 
+        /// <summary>
+        /// The action tiggered when a property changes
+        /// </summary>
         public virtual event Action? Changed;
 
+        /// <summary>
+        /// Constructs a new <see cref="GraphElement"/>
+        /// </summary>
         protected GraphElement() 
         { }
 
+        /// <summary>
+        /// Constructs a new <see cref="GraphElement"/>
+        /// </summary>
+        /// <param name="label">The element's label</param>
+        /// <param name="cssClass">The element's css class(es)</param>
+        /// <param name="componentType">The element's component(template) type</param>
         protected GraphElement(string? label = "", string? cssClass = null, Type? componentType = null) {
             this.Label = label;
             this.CssClass = cssClass;
             this.ComponentType = componentType;
         }
 
+        /// <summary>
+        /// Invokes the change action
+        /// </summary>
         protected virtual void OnChange()
         {
             this.Changed?.Invoke();

--- a/src/Blazor/Neuroglia.Blazor.Dagre/Models/GraphViewModel.cs
+++ b/src/Blazor/Neuroglia.Blazor.Dagre/Models/GraphViewModel.cs
@@ -109,7 +109,16 @@ namespace Neuroglia.Blazor.Dagre.Models
         protected readonly Collection<Type> _svgDefinitionComponents;
         public virtual IReadOnlyCollection<Type> SvgDefinitionComponents => this._svgDefinitionComponents;
 
-        public virtual bool EnableProfiling { get; set; }
+        protected bool _enableProfiling = false;
+        public virtual bool EnableProfiling
+        {
+            get => this._enableProfiling;
+            set
+            {
+                this._enableProfiling = value;
+                this.OnChange();
+            }
+        }
 
         /// <summary>
         /// The map of node type and their component type

--- a/src/Blazor/Neuroglia.Blazor.Dagre/Models/NodeViewModel.cs
+++ b/src/Blazor/Neuroglia.Blazor.Dagre/Models/NodeViewModel.cs
@@ -3,7 +3,7 @@
     public class NodeViewModel
         : GraphElement, INodeViewModel
     {
-        protected double? _x { get; set; }
+        protected double? _x = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public virtual double? X { 
@@ -15,7 +15,7 @@
             }
         }
 
-        protected double? _y { get; set; }
+        protected double? _y = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public virtual double? Y
@@ -28,7 +28,7 @@
             }
         }
 
-        protected double? _width { get; set; }
+        protected double? _width = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public virtual double? Width
@@ -41,7 +41,7 @@
             }
         }
 
-        protected double? _height { get; set; }
+        protected double? _height = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public virtual double? Height
@@ -54,23 +54,59 @@
             }
         }
 
+        protected double? _radiusX = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public virtual double? RadiusX { get; set; }
+        public virtual double? RadiusX
+        {
+            get => this._radiusX;
+            set
+            {
+                this._radiusX = value;
+                this.OnChange();
+            }
+        }
 
+        protected double? _radiusY = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public virtual double? RadiusY { get; set; }
+        public virtual double? RadiusY
+        {
+            get => this._radiusY;
+            set
+            {
+                this._radiusY = value;
+                this.OnChange();
+            }
+        }
 
+        protected Guid? _parentId = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public virtual Guid? ParentId { get; set; }
+        public virtual Guid? ParentId
+        {
+            get => this._parentId;
+            set
+            {
+                this._parentId = value;
+                this.OnChange();
+            }
+        }
 
+        protected string? _shape = null;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public virtual string? Shape { get; set; }
+        public virtual string? Shape
+        {
+            get => this._shape;
+            set
+            {
+                this._shape = value;
+                this.OnChange();
+            }
+        }
 
-        protected IBoundingBox _bbox { get; set; }
+        protected IBoundingBox _bbox = null!;
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [Newtonsoft.Json.JsonProperty(NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public virtual IBoundingBox? BBox => this._bbox;


### PR DESCRIPTION
Some properties were not triggering the `Changed` action in `Neuroglia.Blazor.Dagre`, especially in `GraphElement`.

Most properties will now trigger the changed action when set.