### PR TITLE
Removed the non-generic Snapshot abstract class to avoid clashes during serialization (i.e. duplicated data property)

### DIFF
--- a/src/Data/Neuroglia.Data.EventSourcing/Neuroglia.Data.EventSourcing.xml
+++ b/src/Data/Neuroglia.Data.EventSourcing/Neuroglia.Data.EventSourcing.xml
@@ -909,45 +909,6 @@
             <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken"/></param>
             <returns>A new awaitable <see cref="T:System.Threading.Tasks.Task"/></returns>
         </member>
-        <member name="T:Neuroglia.Data.EventSourcing.Snapshot">
-            <summary>
-            Represents the snapshot envelope of an <see cref="T:Neuroglia.Data.IAggregateRoot"/>
-            </summary>
-        </member>
-        <member name="M:Neuroglia.Data.EventSourcing.Snapshot.#ctor">
-            <summary>
-            Initializes a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/>
-            </summary>
-        </member>
-        <member name="M:Neuroglia.Data.EventSourcing.Snapshot.#ctor(Neuroglia.Data.IAggregateRoot,System.Object)">
-            <summary>
-            Initializes a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/>
-            </summary>
-            <param name="data">The <see cref="T:Neuroglia.Data.IAggregateRoot"/> to snapshot</param>
-            <param name="metadata">The metadata of the <see cref="T:Neuroglia.Data.EventSourcing.Snapshot"/> to create</param>
-        </member>
-        <member name="M:Neuroglia.Data.EventSourcing.Snapshot.#ctor(Neuroglia.Data.IAggregateRoot)">
-            <summary>
-            Initializes a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/>
-            </summary>
-            <param name="data">The <see cref="T:Neuroglia.Data.IAggregateRoot"/> to snapshot</param>
-        </member>
-        <member name="P:Neuroglia.Data.EventSourcing.Snapshot.Version">
-            <inheritdoc/>
-        </member>
-        <member name="P:Neuroglia.Data.EventSourcing.Snapshot.Data">
-            <inheritdoc/>
-        </member>
-        <member name="P:Neuroglia.Data.EventSourcing.Snapshot.Metadata">
-            <inheritdoc/>
-        </member>
-        <member name="M:Neuroglia.Data.EventSourcing.Snapshot.CreateFor``1(``0)">
-            <summary>
-            Creates a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/> for the specified <see cref="T:Neuroglia.Data.IAggregateRoot"/>
-            </summary>
-            <param name="aggregate">The <see cref="T:Neuroglia.Data.IAggregateRoot"/> to create a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/> for</param>
-            <returns>A new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/> of the specified <see cref="T:Neuroglia.Data.IAggregateRoot"/></returns>
-        </member>
         <member name="T:Neuroglia.Data.EventSourcing.Snapshot`1">
             <summary>
             Represents the snapshot envelope of an <see cref="T:Neuroglia.Data.IAggregateRoot"/>
@@ -970,9 +931,28 @@
             <summary>
             Initializes a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/>
             </summary>
+            <param name="data">The <see cref="T:Neuroglia.Data.IAggregateRoot"/> to snapshot</param>
         </member>
         <member name="P:Neuroglia.Data.EventSourcing.Snapshot`1.Data">
             <inheritdoc/>
+        </member>
+        <member name="P:Neuroglia.Data.EventSourcing.Snapshot`1.Version">
+            <inheritdoc/>
+        </member>
+        <member name="P:Neuroglia.Data.EventSourcing.Snapshot`1.Metadata">
+            <inheritdoc/>
+        </member>
+        <member name="T:Neuroglia.Data.EventSourcing.Snapshot">
+            <summary>
+            Defines helpers methods to handle <see cref="T:Neuroglia.Data.EventSourcing.ISnapshot"/>s
+            </summary>
+        </member>
+        <member name="M:Neuroglia.Data.EventSourcing.Snapshot.CreateFor``1(``0)">
+            <summary>
+            Creates a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/> for the specified <see cref="T:Neuroglia.Data.IAggregateRoot"/>
+            </summary>
+            <param name="aggregate">The <see cref="T:Neuroglia.Data.IAggregateRoot"/> to create a new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/> for</param>
+            <returns>A new <see cref="T:Neuroglia.Data.EventSourcing.Snapshot`1"/> of the specified <see cref="T:Neuroglia.Data.IAggregateRoot"/></returns>
         </member>
         <member name="T:Neuroglia.Data.EventSourcing.SourcedEvent">
             <summary>

--- a/src/Data/Neuroglia.Data.EventSourcing/Snapshot.cs
+++ b/src/Data/Neuroglia.Data.EventSourcing/Snapshot.cs
@@ -21,68 +21,9 @@ namespace Neuroglia.Data.EventSourcing
     /// <summary>
     /// Represents the snapshot envelope of an <see cref="IAggregateRoot"/>
     /// </summary>
-    public abstract class Snapshot
-        : ISnapshot
-    {
-
-        /// <summary>
-        /// Initializes a new <see cref="Snapshot{TKey}"/>
-        /// </summary>
-        protected Snapshot()
-        {
-
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="Snapshot{TKey}"/>
-        /// </summary>
-        /// <param name="data">The <see cref="IAggregateRoot"/> to snapshot</param>
-        /// <param name="metadata">The metadata of the <see cref="Snapshot"/> to create</param>
-        protected Snapshot(IAggregateRoot data, object metadata)
-        {
-            this.Version = data.StateVersion;
-            this.Data = data;
-            this.Metadata = metadata;
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="Snapshot{TKey}"/>
-        /// </summary>
-        /// <param name="data">The <see cref="IAggregateRoot"/> to snapshot</param>
-        protected Snapshot(IAggregateRoot data)
-            : this(data, null)
-        {
-   
-        }
-
-        /// <inheritdoc/>
-        public virtual long Version { get; protected set; }
-
-        /// <inheritdoc/>
-        public virtual IAggregateRoot Data { get; protected set; }
-
-        /// <inheritdoc/>
-        public virtual object Metadata { get; protected set; }
-
-        /// <summary>
-        /// Creates a new <see cref="Snapshot{TAggregate}"/> for the specified <see cref="IAggregateRoot"/>
-        /// </summary>
-        /// <param name="aggregate">The <see cref="IAggregateRoot"/> to create a new <see cref="Snapshot{TAggregate}"/> for</param>
-        /// <returns>A new <see cref="Snapshot{TAggregate}"/> of the specified <see cref="IAggregateRoot"/></returns>
-        public static Snapshot<TAggregate> CreateFor<TAggregate>(TAggregate aggregate)
-            where TAggregate : class, IAggregateRoot
-        {
-            return new(aggregate);
-        }
-
-    }
-
-    /// <summary>
-    /// Represents the snapshot envelope of an <see cref="IAggregateRoot"/>
-    /// </summary>
     /// <typeparam name="TAggregate">The type of the snapshot <see cref="IAggregateRoot"/></typeparam>
     public class Snapshot<TAggregate>
-        : Snapshot, ISnapshot<TAggregate>
+        : ISnapshot<TAggregate>
         where TAggregate : class, IAggregateRoot
     {
 
@@ -100,31 +41,50 @@ namespace Neuroglia.Data.EventSourcing
         /// <param name="data">The <see cref="IAggregateRoot"/> to snapshot</param>
         /// <param name="metadata">The metadata of the <see cref="Snapshot"/> to create</param>
         public Snapshot(TAggregate data, object metadata)
-            : base(data, metadata)
         {
-
+            this.Version = data.StateVersion;
+            this.Data = data;
+            this.Metadata = metadata;
         }
 
         /// <summary>
         /// Initializes a new <see cref="Snapshot{TKey}"/>
         /// </summary>
+        /// <param name="data">The <see cref="IAggregateRoot"/> to snapshot</param>
         public Snapshot(TAggregate data)
-            : base(data, null)
+            : this(data, null)
         {
 
         }
 
         /// <inheritdoc/>
-        public new virtual TAggregate Data
+        public virtual TAggregate Data { get; protected set; }
+
+        IAggregateRoot ISnapshot.Data => this.Data;
+
+        /// <inheritdoc/>
+        public virtual long Version { get; protected set; }
+
+        /// <inheritdoc/>
+        public virtual object Metadata { get; protected set; }
+
+    }
+
+    /// <summary>
+    /// Defines helpers methods to handle <see cref="ISnapshot"/>s
+    /// </summary>
+    public static class Snapshot
+    {
+
+        /// <summary>
+        /// Creates a new <see cref="Snapshot{TAggregate}"/> for the specified <see cref="IAggregateRoot"/>
+        /// </summary>
+        /// <param name="aggregate">The <see cref="IAggregateRoot"/> to create a new <see cref="Snapshot{TAggregate}"/> for</param>
+        /// <returns>A new <see cref="Snapshot{TAggregate}"/> of the specified <see cref="IAggregateRoot"/></returns>
+        public static Snapshot<TAggregate> CreateFor<TAggregate>(TAggregate aggregate)
+            where TAggregate : class, IAggregateRoot
         {
-            get
-            {
-                return (TAggregate)base.Data;
-            }
-            protected set
-            {
-                base.Data = value;
-            }
+            return new(aggregate);
         }
 
     }

--- a/src/Data/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.xml
+++ b/src/Data/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.xml
@@ -112,10 +112,10 @@
         </member>
         <member name="M:Neuroglia.Data.Expressions.JQ.JQExpressionEvaluator.EscapeArgs(System.String)">
             <summary>
-            Escapes double quotes or slashes in the specified string
+            Escapes double quotes (") or backslashes (\) in the provided string
             </summary>
-            <param name="input">The string for which to escape double quotes</param>
-            <returns>The string with escaped double quotes</returns>
+            <param name="input">The string to escape</param>
+            <returns>The escaped string</returns>
         </member>
     </members>
 </doc>


### PR DESCRIPTION
Removes the non-generic Snapshot abstract class to avoid clashes during serialization (i.e. duplicated data property)