### PR TITLE
Added a new MapAttribute, used to mark the types an object is mappable to, as well as Profile extensions, used to automatically register mapped types and apply discovered IMappingConfigurations

### DIFF
--- a/src/Neuroglia.Mapping/Attributes/MapAttribute.cs
+++ b/src/Neuroglia.Mapping/Attributes/MapAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Mapping;
+
+/// <summary>
+/// Represents an <see cref="Attribute"/> used to mark a type as mappable to another 
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class MapAttribute
+    : Attribute
+{
+
+    /// <summary>
+    /// Initializes a new <see cref="MapAttribute"/>
+    /// </summary>
+    /// <param name="destinationType">The type to which the class is mappable</param>
+    public MapAttribute(Type destinationType) { this.DestinationType = destinationType ?? throw new ArgumentNullException(nameof(destinationType)); }
+
+    /// <summary>
+    /// Gets the type to which the class is mappable
+    /// </summary>
+    public virtual Type DestinationType { get; }
+
+}

--- a/src/Neuroglia.Mapping/Extensions/ProfileExtensions.cs
+++ b/src/Neuroglia.Mapping/Extensions/ProfileExtensions.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 
 namespace Neuroglia.Mapping;
@@ -21,10 +22,7 @@ namespace Neuroglia.Mapping;
 public static class ProfileExtensions
 {
 
-    private static readonly MethodInfo GenericApplyConfigurationMethod = typeof(ProfileExtensions)
-        .GetMethods(BindingFlags.Default | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-        .Where(m => m.Name == nameof(ApplyConfiguration) && m.IsGenericMethod)
-        .First();
+    static readonly MethodInfo GenericApplyConfigurationMethod = typeof(ProfileExtensions).GetMethods(BindingFlags.Default | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static).Where(m => m.Name == nameof(ApplyConfiguration) && m.IsGenericMethod).First();
 
     /// <summary>
     /// Applies the specified configuration
@@ -33,10 +31,7 @@ public static class ProfileExtensions
     /// <typeparam name="TDestination">The type to map to</typeparam>
     /// <param name="profile">The <see cref="AutoMapper.Profile"/> to configure</param>
     /// <param name="configuration">The <see cref="IMappingConfiguration{TSource, TDestination}"/> to apply</param>
-    public static void ApplyConfiguration<TSource, TDestination>(this AutoMapper.Profile profile, IMappingConfiguration<TSource, TDestination> configuration)
-    {
-        configuration.Configure(profile.CreateMap<TSource, TDestination>());
-    }
+    public static void ApplyConfiguration<TSource, TDestination>(this AutoMapper.Profile profile, IMappingConfiguration<TSource, TDestination> configuration) => configuration.Configure(profile.CreateMap<TSource, TDestination>());
 
     /// <summary>
     /// Applies the specified <see cref="IMappingConfiguration"/>
@@ -52,6 +47,27 @@ public static class ProfileExtensions
             var sourceType = configurationType.GetGenericArguments()[0];
             var destinationType = configurationType.GetGenericArguments()[1];
             GenericApplyConfigurationMethod.MakeGenericMethod(sourceType, destinationType).Invoke(null, new object[] { profile, configuration });
+        }
+    }
+
+    /// <summary>
+    /// Applies all <see cref="IMappingConfiguration"/>s found in the specified assemblies and registers all type maps configured using <see cref="MapAttribute"/>s
+    /// </summary>
+    /// <param name="profile">The extended <see cref="AutoMapper.Profile"/></param>
+    /// <param name="serviceProvider">The current <see cref="IServiceProvider"/></param>
+    /// <param name="assemblies">An array containing the assemblies to search for <see cref="IMappingConfiguration"/>s. If null or empty, will search the calling <see cref="Assembly"/></param>
+    public static void Configure(this AutoMapper.Profile profile, IServiceProvider serviceProvider, params Assembly[] assemblies)
+    {
+        if(assemblies == null || !assemblies.Any()) assemblies = new Assembly[] { Assembly.GetCallingAssembly() };
+        var types = assemblies.SelectMany(a => a.GetTypes());
+        foreach(var mappingConfigurationType in types.Where(t => !t.IsAbstract && !t.IsInterface && t.IsClass && typeof(IMappingConfiguration).IsAssignableFrom(t)))
+        {
+            profile.ApplyConfiguration((IMappingConfiguration)ActivatorUtilities.CreateInstance(serviceProvider, mappingConfigurationType));
+        }
+        foreach(var sourceType in types.Where(t => t.TryGetCustomAttribute<MapAttribute>(out _)))
+        {
+            var mapAttribute = sourceType.GetCustomAttribute<MapAttribute>()!;
+            profile.CreateMap(sourceType, mapAttribute.DestinationType);
         }
     }
 


### PR DESCRIPTION
- Added a new MapAttribute, used to mark the types an object is mappable to, as well as Profile extensions, used to automatically register mapped types and apply discovered IMappingConfigurations