### PR TITLE
Add NSM implementation

### DIFF
--- a/src/Neuroglia.Core/Extensions/ICollectionExtensions.cs
+++ b/src/Neuroglia.Core/Extensions/ICollectionExtensions.cs
@@ -1,0 +1,69 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+
+namespace Neuroglia;
+
+/// <summary>
+/// Defines extensions for <see cref="ICollection"/>s
+/// </summary>
+public static class ICollectionExtensions
+{
+
+    /// <summary>
+    /// Adds the specified item to the collection
+    /// </summary>
+    /// <param name="collection">The extended <see cref="ICollection"/></param>
+    /// <param name="item">The item to add</param>
+    public static void Add(this ICollection collection, object item)
+    {
+        var itemType = collection.GetType().GetEnumerableElementType();
+        typeof(ICollection<>).MakeGenericType(itemType).GetMethod(nameof(Add))!.Invoke(collection, new object[] { item });
+    }
+
+    /// <summary>
+    /// Determines whether or not the collection contains the specified item
+    /// </summary>
+    /// <param name="collection">The extended <see cref="ICollection"/></param>
+    /// <param name="item">The item to check</param>
+    /// <returns>A boolean indicating whether or not the collection contains the specified item</returns>
+    public static bool Contains(this ICollection collection, object item)
+    {
+        var itemType = collection.GetType().GetEnumerableElementType();
+        return (bool)typeof(ICollection<>).MakeGenericType(itemType).GetMethod(nameof(Contains))!.Invoke(collection, new object[] { item })!;
+    }
+
+    /// <summary>
+    /// Removes the specified item from the collection
+    /// </summary>
+    /// <param name="collection">The extended <see cref="ICollection"/></param>
+    /// <param name="item">The item to remove</param>
+    /// <returns>A boolean indicating whether or not the specified item was removed from the collection</returns>
+    public static bool Remove(this ICollection collection, object item)
+    {
+        var itemType = collection.GetType().GetEnumerableElementType();
+        return (bool)typeof(ICollection<>).MakeGenericType(itemType).GetMethod(nameof(Remove))!.Invoke(collection, new object[] { item })!;
+    }
+
+    /// <summary>
+    /// Clears the collection
+    /// </summary>
+    /// <param name="collection">The extended <see cref="ICollection"/></param>
+    public static void Clear(this ICollection collection)
+    {
+        var itemType = collection.GetType().GetEnumerableElementType();
+        typeof(ICollection<>).MakeGenericType(itemType).GetMethod(nameof(Clear))!.Invoke(collection, Array.Empty<object>());
+    }
+
+}

--- a/src/Neuroglia.Core/Extensions/IEnumerableExtensions.cs
+++ b/src/Neuroglia.Core/Extensions/IEnumerableExtensions.cs
@@ -23,6 +23,7 @@ public static class IEnumerableExtensions
 {
 
     static readonly MethodInfo OfTypeMethod = typeof(Enumerable).GetMethod(nameof(Enumerable.OfType))!;
+    static readonly MethodInfo ToListMethod = typeof(Enumerable).GetMethod(nameof(Enumerable.ToList))!;
 
     /// <summary>
     /// Converts the <see cref="IEnumerable{T}"/> into a new <see cref="EquatableList{T}"/>
@@ -31,7 +32,23 @@ public static class IEnumerableExtensions
     /// <param name="source">The <see cref="IEnumerable{T}"/> to convert</param>
     /// <returns>A new <see cref="EquatableList{T}"/></returns>
     public static EquatableList<T> WithValueSemantics<T>(this IEnumerable<T> source) => new(source);
-    
+
+    /// <summary>
+    /// Gets the element at the specified index
+    /// </summary>
+    /// <param name="enumerable">The extended collection</param>
+    /// <param name="index">The index of the element to get</param>
+    /// <returns>The element at the specified index</returns>
+    public static object GetElementAt(this IEnumerable enumerable, int index)
+    {
+        var i = 0;
+        foreach (var item in enumerable)
+        {
+            if (i == index) return item;
+        }
+        throw new ArgumentOutOfRangeException(nameof(index));
+    }
+
     /// <summary>
     /// Filters the elements of a sequence based on a specified type
     /// </summary>
@@ -39,5 +56,12 @@ public static class IEnumerableExtensions
     /// <param name="type">The type to filter the sequence by</param>
     /// <returns>A new <see cref="IEnumerable"/></returns>
     public static IEnumerable OfType(this IEnumerable enumerable, Type type) => (IEnumerable)OfTypeMethod.MakeGenericMethod(type).Invoke(null, new object[] { enumerable })!;
+
+    /// <summary>
+    /// Converts the <see cref="IEnumerable"/> into a new <see cref="IList"/>
+    /// </summary>
+    /// <param name="enumerable">The <see cref="IEnumerable"/> to convert</param>
+    /// <returns>A new <see cref="IList"/></returns>
+    public static IList ToNonGenericList(this IEnumerable enumerable) => (IList)ToListMethod.MakeGenericMethod(enumerable.GetType().GetEnumerableElementType()).Invoke(null, new object[] { enumerable })!;
 
 }

--- a/src/Neuroglia.Core/Extensions/IListExtensions.cs
+++ b/src/Neuroglia.Core/Extensions/IListExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+using System.Reflection;
+
+namespace Neuroglia;
+
+/// <summary>
+/// Defines extensions for <see cref="IList"/>s
+/// </summary>
+public static class IListExtensions
+{
+
+    static readonly MethodInfo InsertMethod = typeof(IList<>).GetMethod(nameof(Insert))!;
+
+    /// <summary>
+    /// Inserts the specified item in the list
+    /// </summary>
+    /// <param name="list">The extended <see cref="IList"/></param>
+    /// <param name="index">The index to insert the specified item at</param>
+    /// <param name="item">The item to insert</param>
+    public static void Insert(this IList list, int index, object item)
+    {
+        var itemType = list.GetType().GetEnumerableElementType();
+        InsertMethod.MakeGenericMethod(itemType).Invoke(list, new object[] { index, item });
+    }
+
+}

--- a/src/Neuroglia.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Neuroglia.Core/Extensions/MemberInfoExtensions.cs
@@ -56,3 +56,4 @@ public static class MemberInfoExtensions
     }
 
 }
+

--- a/src/Neuroglia.Core/Extensions/TypeExtensions.cs
+++ b/src/Neuroglia.Core/Extensions/TypeExtensions.cs
@@ -280,4 +280,18 @@ public static class TypeExtensions
         return false;
     }
 
+    public static int GetAscendencyLevel(this Type extended, Type ancestor)
+    {
+        if (extended == ancestor) return 0;
+        Type? baseType = extended;
+        var level = 0;
+        do
+        {
+            level++;
+            baseType = baseType?.BaseType;
+        }
+        while (baseType != null && baseType != ancestor);
+        return level;
+    }
+
 }

--- a/src/Neuroglia.Core/Extensions/TypeExtensions.cs
+++ b/src/Neuroglia.Core/Extensions/TypeExtensions.cs
@@ -280,6 +280,12 @@ public static class TypeExtensions
         return false;
     }
 
+    /// <summary>
+    /// Gets the ascendency level of the specified ancestor type compared to the type
+    /// </summary>
+    /// <param name="extended">The type to check</param>
+    /// <param name="ancestor">The ancestor type to compare the type to</param>
+    /// <returns>The anscendency level of the specified ancestor type</returns>
     public static int GetAscendencyLevel(this Type extended, Type ancestor)
     {
         if (extended == ancestor) return 0;

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing/Services/EventAggregator.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing/Services/EventAggregator.cs
@@ -142,7 +142,8 @@ public class EventAggregator<TState, TEvent>
             if (e == null || !this.Reducers.TryGetValue(e.GetType(), out var reducer) || reducer == null) continue;
             reducer.Reduce(e, state);
         }
-        if (state is IVersionedState versionedState) versionedState.StateVersion += (ulong)events.Count();
+        if (state is IAggregateRoot aggregateRoot) aggregateRoot.State.StateVersion += (ulong)events.Count();
+        else if (state is IVersionedState versionedState) versionedState.StateVersion += (ulong)events.Count();
         return state;
     }
 

--- a/src/Neuroglia.Data.PatchModel/Attributes/JsonPatchOperationAttribute.cs
+++ b/src/Neuroglia.Data.PatchModel/Attributes/JsonPatchOperationAttribute.cs
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 using Json.Patch;
+using Neuroglia.Data.PatchModel.Services;
 
-namespace Neuroglia.Data.PatchModel.Attributes;
+namespace Neuroglia.Data.PatchModel;
 
 /// <summary>
 /// Represents an attribute used to marked methods as Json Patch reducers
@@ -28,25 +29,17 @@ public class JsonPatchOperationAttribute
     /// </summary>
     /// <param name="type">The type of the supported Json Patch operation</param>
     /// <param name="path">The supported Json Patch path</param>
-    public JsonPatchOperationAttribute(string type, string path)
+    public JsonPatchOperationAttribute(JsonPatchOperationType type, string path)
     {
-        if (string.IsNullOrWhiteSpace(type)) throw new ArgumentNullException(nameof(type));
         if (string.IsNullOrWhiteSpace(path)) throw new ArgumentNullException(nameof(path));
         this.Type = type;
         this.Path = path;
     }
 
     /// <summary>
-    /// Initializes a new <see cref="JsonPatchOperationAttribute"/>
-    /// </summary>
-    /// <param name="type">The type of the supported Json Patch operation</param>
-    /// <param name="path">The supported Json Patch path</param>
-    public JsonPatchOperationAttribute(OperationType type, string path) : this(type.ToString().ToLower(), path) { }
-
-    /// <summary>
     /// Gets the type of the supported Json Patch operation
     /// </summary>
-    public virtual string Type { get; }
+    public virtual JsonPatchOperationType Type { get; }
 
     /// <summary>
     /// Gets the supported Json Patch path

--- a/src/Neuroglia.Data.PatchModel/Extensions/JsonPointerExtensions.cs
+++ b/src/Neuroglia.Data.PatchModel/Extensions/JsonPointerExtensions.cs
@@ -28,4 +28,18 @@ public static class JsonPointerExtensions
     /// <returns>A new <see cref="JsonPointer"/></returns>
     public static JsonPointer ToCamelCase(this JsonPointer pointer) => JsonPointer.Create(pointer.Segments.Select(s => PointerSegment.Parse(s.Value.ToCamelCase())).ToArray());
 
+    /// <summary>
+    /// Determines whether or not the <see cref="JsonPointer"/> is an array indexer
+    /// </summary>
+    /// <param name="pointer">The <see cref="JsonPointer"/> to check</param>
+    /// <returns>A boolean indicating whether or not the <see cref="JsonPointer"/> is an array indexer</returns>
+    public static bool IsArrayIndexer(this JsonPointer pointer) => int.TryParse(pointer.Segments.Last().Value, out _);
+
+    /// <summary>
+    /// Creates a new <see cref="JsonPointer"/> without indexer
+    /// </summary>
+    /// <param name="pointer">The <see cref="JsonPointer"/> to remove the indexer of</param>
+    /// <returns>A new <see cref="JsonPointer"/></returns>
+    public static JsonPointer WithoutArrayIndexer(this JsonPointer pointer) => pointer.IsArrayIndexer() ? JsonPointer.Create(pointer.Segments[..^1]) : pointer;
+
 }

--- a/src/Neuroglia.Data.PatchModel/JsonPatchOperationType.cs
+++ b/src/Neuroglia.Data.PatchModel/JsonPatchOperationType.cs
@@ -1,0 +1,46 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Data.PatchModel;
+
+/// <summary>
+/// Enumerates all JSON Patch operation type flags
+/// </summary>
+[Flags]
+public enum JsonPatchOperationType
+{
+    /// <summary>
+    /// Indicates an 'add' operation
+    /// </summary>
+    Add = 1,
+    /// <summary>
+    /// Indicates a 'copy' operation
+    /// </summary>
+    Copy = 2,
+    /// <summary>
+    /// Indicates a 'move' operation
+    /// </summary>
+    Move = 4,
+    /// <summary>
+    /// Indicates a 'remove' operation
+    /// </summary>
+    Remove = 8,
+    /// <summary>
+    /// Indicates a 'replace' operation
+    /// </summary>
+    Replace = 16,
+    /// <summary>
+    /// Indicates a 'test' operation
+    /// </summary>
+    Test = 32
+}

--- a/src/Neuroglia.Data.PatchModel/JsonPatchPropertyInfo.cs
+++ b/src/Neuroglia.Data.PatchModel/JsonPatchPropertyInfo.cs
@@ -1,0 +1,85 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Json.Patch;
+
+namespace Neuroglia.Data.PatchModel;
+
+/// <summary>
+/// Represents an object used to describe a JSON patchable property
+/// </summary>
+public class JsonPatchPropertyInfo
+{
+
+    /// <summary>
+    /// Initializes a new <see cref="JsonPatchPropertyInfo"/>
+    /// </summary>
+    /// <param name="path">The path to the described property</param>
+    /// <param name="type">The type of the described property</param>
+    /// <param name="getValueDelegate"></param>
+    public JsonPatchPropertyInfo(string path, Type type, Func<IServiceProvider, object, CancellationToken, Task<object?>> getValueDelegate)
+    {
+        this.Path = path;
+        this.Type = type;
+        this.GetValueAsync = getValueDelegate;
+    }
+
+    /// <summary>
+    /// Gets the path to the described property
+    /// </summary>
+    public virtual string Path { get; protected set; }
+
+    /// <summary>
+    /// Gets the type of the described property
+    /// </summary>
+    public virtual Type Type { get; protected set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to get the value of the describe property
+    /// </summary>
+    public virtual Func<IServiceProvider, object, CancellationToken, Task<object?>> GetValueAsync { get; protected set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to handle JSON Patch operations of type <see cref="OperationType.Add"/>, if any
+    /// </summary>
+    public virtual Func<IServiceProvider, object, PatchOperation, CancellationToken, Task>? AddAsync { get; set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to handle JSON Patch operations of type <see cref="OperationType.Copy"/>, if any
+    /// </summary>
+    public virtual Func<IServiceProvider, object, PatchOperation, CancellationToken, Task>? CopyAsync { get; set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to handle JSON Patch operations of type <see cref="OperationType.Move"/>, if any
+    /// </summary>
+    public virtual Func<IServiceProvider, object, PatchOperation, CancellationToken, Task>? MoveAsync { get; set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to handle JSON Patch operations of type <see cref="OperationType.Remove"/>, if any
+    /// </summary>
+    public virtual Func<IServiceProvider, object, PatchOperation, CancellationToken, Task>? RemoveAsync { get; set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to handle JSON Patch operations of type <see cref="OperationType.Replace"/>, if any
+    /// </summary>
+    public virtual Func<IServiceProvider, object, PatchOperation, CancellationToken, Task>? ReplaceAsync { get; set; }
+
+    /// <summary>
+    /// Gets the delegate <see cref="Func{T1, T2, T3, TResult}"/> used to handle JSON Patch operations of type <see cref="OperationType.Test"/>, if any
+    /// </summary>
+    public virtual Func<IServiceProvider, object, PatchOperation, CancellationToken, Task>? TestAsync { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString() => this.Path;
+
+}

--- a/src/Neuroglia.Data.PatchModel/JsonPatchTypeInfo.cs
+++ b/src/Neuroglia.Data.PatchModel/JsonPatchTypeInfo.cs
@@ -1,0 +1,497 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Json.Patch;
+using Json.Pointer;
+using Microsoft.Extensions.DependencyInjection;
+using Neuroglia.Data.Infrastructure.Services;
+using Neuroglia.Data.PatchModel.Services;
+using Neuroglia.Serialization.Json;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Neuroglia.Data.PatchModel;
+
+/// <summary>
+/// Represents an object used to store JSON Patch related information about a type
+/// </summary>
+public class JsonPatchTypeInfo
+{
+
+    static readonly ConcurrentDictionary<Type, JsonPatchTypeInfo> Registry = new();
+
+    readonly List<JsonPatchPropertyInfo> _properties = new();
+    /// <summary>
+    /// Gets a list containing the type's properties
+    /// </summary>
+    public virtual IReadOnlyCollection<JsonPatchPropertyInfo> Properties => _properties.AsReadOnly();
+
+    /// <summary>
+    /// Gets the <see cref="JsonPatchPropertyInfo"/> at the specified path, if any
+    /// </summary>
+    /// <param name="path">The path of the <see cref="JsonPatchPropertyInfo"/> to get</param>
+    /// <returns>The <see cref="JsonPatchPropertyInfo"/> at the specified path, if any</returns>
+    public virtual JsonPatchPropertyInfo? GetProperty(JsonPointer path)
+    {
+        var pathStr = path.ToString();
+        if (int.TryParse(path.Segments.Last().Value, out var index)) pathStr = JsonPointer.Create(path.Segments[..^1]).ToString();
+        return Properties.First(p => p.Path.Equals(pathStr, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the an object's property
+    /// </summary>
+    /// <param name="provider">The current <see cref="IServiceProvider"/></param>
+    /// <param name="source">The source object to get the property value of</param>
+    /// <param name="path">The path to the property to get</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>The value of an object's property</returns>
+    public virtual async Task<object?> GetValueAsync(IServiceProvider provider, object source, JsonPointer path, CancellationToken cancellationToken = default)
+    {
+        var property = GetProperty(path) ?? throw new NullReferenceException($"Failed to find a property at path '{path.ToString(JsonPointerStyle.Plain)}'");
+        return await property.GetValueAsync(provider, source, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets an object's property
+    /// </summary>
+    /// <param name="provider">The current <see cref="IServiceProvider"/></param>
+    /// <param name="source">The source object to get the property value of</param>
+    /// <param name="path"></param>
+    /// <param name="value">The path to the property to get</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>A new awaitable <see cref="Task"/></returns>
+    public virtual async Task SetValueAsync(IServiceProvider provider, object source, JsonPointer path, object? value, CancellationToken cancellationToken = default)
+    {
+        var property = GetProperty(path) ?? throw new NullReferenceException($"Failed to find a property at path '{path.ToString(JsonPointerStyle.Plain)}'");
+        if (property.ReplaceAsync == null) throw new NullReferenceException($"The '{nameof(JsonPatchPropertyInfo.ReplaceAsync)}' delegate has not been configured for property at '{path}'");
+        await property.ReplaceAsync(provider, source, PatchOperation.Replace(path, value == null ? null : JsonSerializer.Default.SerializeToNode(value)), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets or creates the <see cref="JsonPatchTypeInfo"/> for the specified type
+    /// </summary>
+    /// <param name="type">The type to get or create the <see cref="JsonPatchTypeInfo"/> of</param>
+    /// <returns>The <see cref="JsonPatchTypeInfo"/> for the specified type</returns>
+    public static JsonPatchTypeInfo GetOrCreate(Type type)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        if (Registry.TryGetValue(type, out var typeInfo) && typeInfo != null) return typeInfo;
+
+        typeInfo = new JsonPatchTypeInfo();
+
+        var propertyContainerType = type;
+        if (typeof(IAggregateRoot).IsAssignableFrom(type)) propertyContainerType = type.GetGenericType(typeof(IAggregateRoot<,>))?.GenericTypeArguments[1] ?? ((IAggregateRoot)Activator.CreateInstance(type, true)!).State.GetType();
+        foreach (var property in propertyContainerType.GetProperties().Where(p => p.CanRead))
+        {
+            var propertyInfo = new JsonPatchPropertyInfo($"/{property.Name.ToCamelCase()}", property.PropertyType, BuildGetValueDelegateFor(property));
+            if (property.GetSetMethod() != null)
+            {
+                propertyInfo.AddAsync = BuildAddOperationDelegateFor(property);
+                propertyInfo.CopyAsync = BuildCopyOperationDelegateFor(property, typeInfo);
+                propertyInfo.MoveAsync = BuildMoveOperationDelegateFor(property, typeInfo);
+                propertyInfo.RemoveAsync = BuildRemoveOperationDelegateFor(property);
+                propertyInfo.ReplaceAsync = BuildReplaceOperationDelegateFor(property);
+                propertyInfo.TestAsync = BuildTestOperationDelegateFor(property);
+            }
+            typeInfo._properties.Add(propertyInfo);
+        }
+
+        foreach (var method in type.GetMethods().Where(m => m.TryGetCustomAttribute<JsonPatchOperationAttribute>(out _)))
+        {
+            var jsonPatchOperationAttribute = method.GetCustomAttribute<JsonPatchOperationAttribute>()!;
+            var property = type.GetProperty(jsonPatchOperationAttribute.Path, BindingFlags.Default | BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var propertyInfo = typeInfo.GetProperty(JsonPointer.Parse($"/{jsonPatchOperationAttribute.Path}")) ?? new JsonPatchPropertyInfo($"/{property.Name.ToCamelCase()}", property.PropertyType, BuildGetValueDelegateFor(property));
+            foreach (var operationType in EnumHelper.GetFlags(jsonPatchOperationAttribute.Type))
+            {
+                switch (operationType)
+                {
+                    case JsonPatchOperationType.Add:
+                        propertyInfo.AddAsync = BuildAddOperationDelegateFor(method, jsonPatchOperationAttribute);
+                        break;
+                    case JsonPatchOperationType.Copy:
+                        propertyInfo.CopyAsync = BuildCopyOperationDelegateFor(method, typeInfo);
+                        break;
+                    case JsonPatchOperationType.Move:
+                        propertyInfo.MoveAsync = BuildMoveOperationDelegateFor(method, typeInfo);
+                        break;
+                    case JsonPatchOperationType.Remove:
+                        propertyInfo.RemoveAsync = BuildRemoveOperationDelegateFor(method);
+                        break;
+                    case JsonPatchOperationType.Replace:
+                        propertyInfo.ReplaceAsync = BuildReplaceOperationDelegateFor(method, jsonPatchOperationAttribute);
+                        break;
+                    case JsonPatchOperationType.Test:
+                        BuildTestOperationDelegateFor(property);
+                        break;
+                    default: throw new NotSupportedException($"The specified {nameof(OperationType)} '{operationType}' is not supported");
+                }
+            }
+        }
+
+        Registry.AddOrUpdate(type, typeInfo, (key, existing) => typeInfo);
+        return typeInfo;
+    }
+
+    /// <summary>
+    /// Gets or creates the <see cref="JsonPatchTypeInfo"/> for the specified type
+    /// </summary>
+    /// <typeparam name="T">The type to get or create the <see cref="JsonPatchTypeInfo"/> of</typeparam>
+    /// <returns>The <see cref="JsonPatchTypeInfo"/> for the specified type</returns>
+    public static JsonPatchTypeInfo GetOrCreate<T>() => GetOrCreate(typeof(T));
+
+    /// <summary>
+    /// Builds a new delegate for getting the value of the specified <see cref="PropertyInfo"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to build the delegate for</param>
+    /// <returns>A new delegate for getting the value of the specified <see cref="PropertyInfo"/></returns>
+    public static Func<IServiceProvider, object, CancellationToken, Task<object?>> BuildGetValueDelegateFor(PropertyInfo property) => (provider, source, cancellationToken) => Task.FromResult(property.GetValue(source is IAggregateRoot aggregate ? aggregate.State : source));
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Add"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to create the delegate for</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Add"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildAddOperationDelegateFor(PropertyInfo property)
+    {
+        return (provider, source, operation, cancellationToken) =>
+        {
+            return Task.Run(() =>
+            {
+                var propertySource = source is IAggregateRoot aggregate ? aggregate.State : source;
+                var sourceValue = property.GetValue(propertySource);
+                var valueToAdd = operation.Value == null ? null : JsonSerializer.Default.Deserialize(operation.Value, property.PropertyType)!;
+                if (int.TryParse(operation.Path.Segments.Last().Value, out var index))
+                {
+                    if (property.PropertyType == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(property.PropertyType)) throw new NotSupportedException($"Cannot index a value of type '{property.PropertyType.Name}'");
+                    if (sourceValue == null) throw new ArgumentOutOfRangeException($"The target property '{property.Name}' is null and cannot be indexed", nameof(index));
+                    if (sourceValue is IList list) list.Insert(index, valueToAdd);
+                    else throw new InvalidOperationException($"The target property '{property.Name}' is not a list type and it cannot be added/inserted items");
+                }
+                else if (sourceValue is ICollection collection && valueToAdd != null) collection.Add(valueToAdd);
+                else
+                {
+                    property.SetValue(propertySource, valueToAdd);
+                    return;
+                }
+            }, cancellationToken);
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Add"/>
+    /// </summary>
+    /// <param name="method">The <see cref="MethodInfo"/> to create the delegate for</param>
+    /// <param name="jsonPatchOperationAttribute">The specified <see cref="MethodInfo"/>'s <see cref="JsonPatchOperationAttribute"/></param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Add"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildAddOperationDelegateFor(MethodInfo method, JsonPatchOperationAttribute jsonPatchOperationAttribute)
+    {
+        var parameters = method.GetParameters();
+        if (parameters.Length < 1 || parameters.Length > 2) throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Add}' must declare a 'value' parameter and optionally an 'index' parameter of type 'int'");
+        return async (provider, source, operation, cancellationToken) =>
+        {
+            object[] args;
+            if (parameters.Length == 1 && parameters.First().ParameterType == typeof(PatchOperation)) args = new object[] { operation };
+            else
+            {
+                var valueParameter = parameters.FirstOrDefault() ?? throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Add}' must declare a 'value' parameter and optionally an 'index' parameter of type 'int'");
+                var indexParameter = parameters.Length > 1 ? parameters[1] : null;
+                var index = (int?)null;
+                if (indexParameter != null)
+                {
+                    var lastPathSegment = operation.Path.Segments.Last().Value;
+                    if (lastPathSegment.All(c => char.IsDigit(c)))
+                    {
+                        if (int.TryParse(lastPathSegment, out var indexValue)) index = indexValue;
+                    }
+                }
+
+                var value = (object?)null;
+                if (jsonPatchOperationAttribute.ReferencedType == null)
+                {
+                    value = operation.Value == null ? null : JsonSerializer.Default.Deserialize(operation.Value, valueParameter.ParameterType)!;
+                }
+                else
+                {
+                    var referencedType = jsonPatchOperationAttribute.ReferencedType;
+                    var keyType = referencedType.GetGenericType(typeof(IIdentifiable<>))?.GetGenericArguments()[0] ?? throw new NullReferenceException($"Failed to determine the type of key used to reference instances of type '{jsonPatchOperationAttribute.ReferencedType.Name}'");
+                    var key = (operation.Value == null ? null : JsonSerializer.Default.Deserialize(operation.Value, keyType)) ?? throw new NullReferenceException($"A JSON Patch operation of type '{OperationType.Add}' must set the '{nameof(operation.Value)}' property when using references");
+                    var repositoryType = typeof(IRepository<,>).MakeGenericType(referencedType, keyType);
+                    var repository = (IRepository)provider.GetRequiredService(repositoryType);
+                    value = await repository.GetAsync(key, cancellationToken).ConfigureAwait(false) ?? throw DomainException.NullReference(referencedType, key);
+                }
+
+                args = indexParameter == null ? new object[] { value! } : new object[] { value!, index! };
+            }
+            method.Invoke(source, args);
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Copy"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to create the delegate for</param>
+    /// <param name="typeInfo">the <see cref="JsonPatchTypeInfo"/> the property to create the delegate for belongs to</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Copy"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildCopyOperationDelegateFor(PropertyInfo property, JsonPatchTypeInfo typeInfo)
+    {
+        return async (provider, source, operation, cancellationToken) =>
+        {
+            if (operation.From == null) throw new NullReferenceException($"A JSON Patch operation of type '{OperationType.Copy}' must set the '{nameof(operation.From)}' property");
+            var propertySource = source is IAggregateRoot aggregate ? aggregate.State : source;
+            var sourceValue = property.GetValue(propertySource);
+            var valueToAdd = await typeInfo.GetValueAsync(provider, source, operation.From, cancellationToken).ConfigureAwait(false);
+            if (int.TryParse(operation.Path.Segments.Last().Value, out var index))
+            {
+                if (property.PropertyType == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(property.PropertyType)) throw new NotSupportedException($"Cannot index a value of type '{property.PropertyType.Name}'");
+                if (sourceValue == null) throw new ArgumentOutOfRangeException($"The target property '{property.Name}' is null and cannot be indexed", nameof(index));
+                if (sourceValue is IList list) list.Insert(index, valueToAdd);
+                else throw new InvalidOperationException($"The target property '{property.Name}' is not a list type and it cannot be added/inserted items");
+            }
+            else if (sourceValue is ICollection collection)
+            {
+                if (valueToAdd is IEnumerable enumerable) foreach (var item in enumerable.OfType<object>().ToList()) collection.Add(item);
+                else collection.Add(valueToAdd!);
+            }
+            else
+            {
+                if (valueToAdd is IEnumerable enumerable && valueToAdd.GetType() != typeof(string)) valueToAdd = enumerable.ToNonGenericList();
+                property.SetValue(propertySource, valueToAdd);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Copy"/>
+    /// </summary>
+    /// <param name="method">The <see cref="MethodInfo"/> to create the delegate for</param>
+    /// <param name="typeInfo">the <see cref="JsonPatchTypeInfo"/> the property to create the delegate for belongs to</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Copy"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildCopyOperationDelegateFor(MethodInfo method, JsonPatchTypeInfo typeInfo)
+    {
+        var parameters = method.GetParameters();
+        if (parameters.Length < 1 || parameters.Length > 2) throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Copy}' must declare a 'values' parameter and optionally an 'index' parameter of type 'int'");
+        return async (provider, source, operation, cancellationToken) =>
+        {
+            if (operation.From == null) throw new NullReferenceException($"A JSON Patch operation of type '{OperationType.Copy}' must set the '{nameof(operation.From)}' property");
+            var sourceValue = await typeInfo.GetValueAsync(provider, source, operation.From, cancellationToken).ConfigureAwait(false);
+            if (sourceValue is IEnumerable enumerable && sourceValue.GetType() != typeof(string)) sourceValue = enumerable.ToNonGenericList();
+            object[] args;
+            if (parameters.Length == 1 && parameters.First().ParameterType == typeof(PatchOperation)) args = new object[] { operation };
+            else
+            {
+                var valueParameter = parameters.FirstOrDefault() ?? throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Add}' must declare a 'value' parameter and optionally an 'index' parameter of type 'int'");
+                var indexParameter = parameters.Length > 1 ? parameters[1] : null;
+                var index = (int?)null;
+                if (indexParameter != null)
+                {
+                    var lastPathSegment = operation.Path.Segments.Last().Value;
+                    if (lastPathSegment.All(c => char.IsDigit(c)))
+                    {
+                        if (int.TryParse(lastPathSegment, out var indexValue)) index = indexValue;
+                    }
+                }
+                args = indexParameter == null ? new object[] { sourceValue! } : new object[] { sourceValue!, index! };
+            }
+            method.Invoke(source, args);
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Move"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to create the delegate for</param>
+    /// <param name="typeInfo">the <see cref="JsonPatchTypeInfo"/> the property to create the delegate for belongs to</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Move"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildMoveOperationDelegateFor(PropertyInfo property, JsonPatchTypeInfo typeInfo)
+    {
+        return async (provider, source, operation, cancellationToken) =>
+        {
+            if (operation.From == null) throw new NullReferenceException($"A JSON Patch operation of type '{OperationType.Add}' must set the '{nameof(operation.From)}' property");
+            var propertySource = source is IAggregateRoot aggregate ? aggregate.State : source;
+            var targetValue = property.GetValue(propertySource);
+            var valueToAdd = await typeInfo.GetValueAsync(provider, source, operation.From, cancellationToken).ConfigureAwait(false);
+            var sourceProperty = typeInfo.GetProperty(operation.From) ?? throw new NullReferenceException($"Failed to find a property at '{operation.Path}'");
+            var sourceValues = (object?)null;
+
+            if (int.TryParse(operation.Path.Segments.Last().Value, out var index))
+            {
+                if (property.PropertyType == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(property.PropertyType)) throw new NotSupportedException($"Cannot index a value of type '{property.PropertyType.Name}'");
+                if (targetValue == null) throw new ArgumentOutOfRangeException($"The target property '{property.Name}' is null and cannot be indexed", nameof(index));
+                if (targetValue is IList list) list.Insert(index, valueToAdd);
+                else throw new InvalidOperationException($"The target property '{property.Name}' is not a list type and it cannot be added/inserted items");
+            }
+            else if (targetValue is ICollection targetCollection && valueToAdd != null)
+            {
+                ICollection? sourceCollection = null;
+                if (valueToAdd is IEnumerable enumerable)
+                {
+                    if (sourceProperty.Type.IsEnumerable() && sourceProperty.Type != typeof(string))
+                    {
+                        sourceValues = await typeInfo.GetValueAsync(provider, source, operation.From.WithoutArrayIndexer(), cancellationToken).ConfigureAwait(false);
+                        sourceCollection = (ICollection)sourceValues!;
+                    }
+                    foreach (var item in enumerable.OfType<object>().ToList())
+                    {
+                        targetCollection.Add(item);
+                        sourceCollection?.Remove(item);
+                    }
+                }
+                else
+                {
+                    if (sourceProperty.Type.IsEnumerable() && sourceProperty.Type != typeof(string) && operation.From.IsArrayIndexer())
+                    {
+                        sourceValues = await typeInfo.GetValueAsync(provider, source, operation.From.WithoutArrayIndexer(), cancellationToken).ConfigureAwait(false);
+                        sourceCollection = (ICollection)sourceValues!;
+                        sourceCollection.Remove(valueToAdd!);
+                    }
+                    targetCollection.Add(valueToAdd!);
+                }
+            }
+            else
+            {
+                property.SetValue(propertySource, valueToAdd);
+                await typeInfo.SetValueAsync(provider, source, operation.From, null, cancellationToken).ConfigureAwait(false);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Move"/>
+    /// </summary>
+    /// <param name="method">The <see cref="MethodInfo"/> to create the delegate for</param>
+    /// <param name="typeInfo">the <see cref="JsonPatchTypeInfo"/> the property to create the delegate for belongs to</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Move"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildMoveOperationDelegateFor(MethodInfo method, JsonPatchTypeInfo typeInfo)
+    {
+        var parameters = method.GetParameters();
+        if (parameters.Length < 1 || parameters.Length > 2) throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Copy}' must declare a 'values' parameter and optionally an 'index' parameter of type 'int'");
+        return async (provider, source, operation, cancellationToken) =>
+        {
+            if (operation.From == null) throw new NullReferenceException($"A JSON Patch operation of type '{OperationType.Copy}' must set the '{nameof(operation.From)}' property");
+            var sourceProperty = typeInfo.GetProperty(operation.From) ?? throw new NullReferenceException($"Failed to find a property at '{operation.Path}'");
+            var sourceValue = (await typeInfo.GetValueAsync(provider, source, operation.From, cancellationToken).ConfigureAwait(false))!;
+            object[] args;
+            if (parameters.Length == 1 && parameters.First().ParameterType == typeof(PatchOperation)) args = new object[] { operation };
+            else
+            {
+                var valueParameter = parameters.FirstOrDefault() ?? throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Add}' must declare a 'value' parameter and optionally an 'index' parameter of type 'int'");
+                var indexParameter = parameters.Length > 1 ? parameters[1] : null;
+                var index = (int?)null;
+                if (indexParameter != null)
+                {
+                    var lastPathSegment = operation.Path.Segments.Last().Value;
+                    if (lastPathSegment.All(c => char.IsDigit(c)))
+                    {
+                        if (int.TryParse(lastPathSegment, out var indexValue)) index = indexValue;
+                    }
+                }
+                args = indexParameter == null ? new object[] { sourceValue! } : new object[] { sourceValue!, index! };
+                if (sourceProperty.Type.IsEnumerable() && sourceProperty.Type != typeof(string) && operation.From.IsArrayIndexer())
+                {
+                    var sourceValues = await typeInfo.GetValueAsync(provider, source, operation.From.WithoutArrayIndexer(), cancellationToken).ConfigureAwait(false);
+                    if (sourceValues is ICollection collection) collection.Remove(sourceValue);
+                    else throw new InvalidOperationException($"The target property at '{sourceProperty.Path}' is not a collection type and does not support removing items");
+                }
+                else
+                {
+                    await typeInfo.SetValueAsync(provider, source, operation.From, null, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            method.Invoke(source, args);
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Remove"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to create the delegate for</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Remove"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildRemoveOperationDelegateFor(PropertyInfo property)
+    {
+        return (provider, source, operation, cancellationToken) =>
+        {
+            return Task.Run(() =>
+            {
+                var propertySource = source is IAggregateRoot aggregate ? aggregate.State : source;
+                var values = property.GetValue(propertySource);
+                if (operation.Path.IsArrayIndexer())
+                {
+                    if (values is ICollection collection) collection.Remove(collection.GetElementAt(int.Parse(operation.Path.Segments.Last().Value)));
+                    else throw new InvalidOperationException($"The targeted property at path '{operation.Path}' is not a collection and does not support removing items");
+                }
+                else property.SetValue(propertySource, null);
+            }, cancellationToken);
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Remove"/>
+    /// </summary>
+    /// <param name="method">The <see cref="MethodInfo"/> to create the delegate for</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Remove"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildRemoveOperationDelegateFor(MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        if (parameters.Length != 1) throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Remove}' must declare exactly one 'index' parameter");
+        return (provider, source, operation, cancellationToken) =>
+        {
+            var indexParameter = parameters.FirstOrDefault(p => typeof(int).IsAssignableFrom(p.ParameterType)) ?? throw new TargetParameterCountException($"A method used to reduce a JSON Patch operation of type '{OperationType.Remove}' must declare exactly one 'index' parameter of type 'int'");
+            if (!int.TryParse(operation.Path.Segments.Last().Value, out var index)) throw new NullReferenceException($"The path of a JSON Patch operation of type '{OperationType.Remove}' must end with the index of the item to remove");
+            return Task.Run(() => method.Invoke(source, new object[] { index }), cancellationToken);
+        };
+    }
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Replace"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to create the delegate for</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Replace"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildReplaceOperationDelegateFor(PropertyInfo property) => BuildAddOperationDelegateFor(property);
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Replace"/>
+    /// </summary>
+    /// <param name="method">The <see cref="MethodInfo"/> to create the delegate for</param>
+    /// <param name="jsonPatchOperationAttribute">The specified <see cref="MethodInfo"/>'s <see cref="JsonPatchOperationAttribute"/></param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Replace"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildReplaceOperationDelegateFor(MethodInfo method, JsonPatchOperationAttribute jsonPatchOperationAttribute) => BuildAddOperationDelegateFor(method, jsonPatchOperationAttribute);
+
+    /// <summary>
+    /// Builds a new delegate for handling a JSON Patch operation of type <see cref="OperationType.Test"/>
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to create the delegate for</param>
+    /// <returns>A new delegate for handling a JSON Patch operation of type <see cref="OperationType.Test"/></returns>
+    public static Func<IServiceProvider, object, PatchOperation, CancellationToken, Task> BuildTestOperationDelegateFor(PropertyInfo property)
+    {
+        return (provider, source, operation, cancellationToken) =>
+        {
+            return Task.Run(() =>
+            {
+                var propertySource = source is IAggregateRoot aggregate ? aggregate.State : source;
+                var value = property.GetValue(propertySource);
+                var valueType = property.PropertyType;
+                if (operation.Path.IsArrayIndexer())
+                {
+                    var enumerableType = valueType.GetGenericType(typeof(IEnumerable<>)) ?? throw new InvalidOperationException($"The targeted property at path '{operation.Path}' is not an enumerable and does not support indexing items"); ;
+                    valueType = enumerableType.GetEnumerableElementType();
+                    if (value is IEnumerable enumerable) value = enumerable.GetElementAt(int.Parse(operation.Path.Segments.Last().Value));
+                }
+                var other = operation.Value == null ? null : JsonSerializer.Default.Deserialize(operation.Value, valueType);
+                if (value?.Equals(other) != true) throw new OptimisticConcurrencyException($"The JSON Patch operation of type '{OperationType.Test}' failed for property at '{operation.Path}'.\r\nExpected value '{other}'\r\nActual value: '{value}'");
+            }, cancellationToken);
+        };
+    }
+
+}

--- a/src/Neuroglia.Data.PatchModel/Neuroglia.Data.PatchModel.csproj
+++ b/src/Neuroglia.Data.PatchModel/Neuroglia.Data.PatchModel.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Neuroglia.Data.Infrastructure.Abstractions\Neuroglia.Data.Infrastructure.Abstractions.csproj" />
     <ProjectReference Include="..\Neuroglia.Serialization.Abstractions\Neuroglia.Serialization.csproj" />
   </ItemGroup>
 

--- a/src/Neuroglia.Data.PatchModel/Services/JsonPatchHandler.cs
+++ b/src/Neuroglia.Data.PatchModel/Services/JsonPatchHandler.cs
@@ -17,7 +17,7 @@ using Neuroglia.Serialization.Json;
 namespace Neuroglia.Data.PatchModel.Services;
 
 /// <summary>
-/// Represents the <see cref="IPatchHandler"/> implementation used to handle Json Patches
+/// Represents the <see cref="IPatchHandler"/> implementation used to handle <see href="https://www.rfc-editor.org/rfc/rfc6902">Json Patches</see>
 /// </summary>
 public class JsonPatchHandler
     : IPatchHandler

--- a/src/Neuroglia.Data.PatchModel/Services/ReflectionBasedJsonPatchHandler.cs
+++ b/src/Neuroglia.Data.PatchModel/Services/ReflectionBasedJsonPatchHandler.cs
@@ -1,0 +1,69 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Json.Patch;
+using Json.Pointer;
+using Neuroglia.Serialization.Json;
+
+namespace Neuroglia.Data.PatchModel.Services;
+
+/// <summary>
+/// Represents a reflection based <see cref="IPatchHandler"/> implementation used to handle <see href="https://www.rfc-editor.org/rfc/rfc6902">Json Patches</see>
+/// </summary>
+public class ReflectionBasedJsonPatchHandler
+    : IPatchHandler
+{
+
+    /// <summary>
+    /// Initializes a new <see cref="ReflectionBasedJsonPatchHandler"/>
+    /// </summary>
+    /// <param name="serviceProvider">The current <see cref="IServiceProvider"/></param>
+    public ReflectionBasedJsonPatchHandler(IServiceProvider serviceProvider) { this.ServiceProvider = serviceProvider;  }
+
+    /// <summary>
+    /// Gets the current <see cref="IServiceProvider"/>
+    /// </summary>
+    protected IServiceProvider ServiceProvider { get; }
+
+    /// <inheritdoc/>
+    public virtual bool Supports(string type) => type == PatchType.JsonPatch;
+
+    /// <inheritdoc/>
+    public virtual async Task<T?> ApplyPatchAsync<T>(object patch, T? target, CancellationToken cancellationToken = default)
+    {
+        if (patch == null) throw new ArgumentNullException(nameof(patch));
+        if (target == null) return default;
+
+        var jsonPatch = JsonSerializer.Default.Deserialize<JsonPatch>(JsonSerializer.Default.SerializeToText(patch))!;
+        var typeInfo = JsonPatchTypeInfo.GetOrCreate<T>();
+
+        foreach(var operation in jsonPatch.Operations)
+        {
+            var property = typeInfo.GetProperty(operation.Path) ?? throw new NullReferenceException($"Failed to find a property at path '{operation.Path}'");
+            var operationDelegate = operation.Op switch
+            {
+                OperationType.Add => property.AddAsync,
+                OperationType.Copy => property.CopyAsync,
+                OperationType.Move => property.MoveAsync,
+                OperationType.Remove => property.RemoveAsync,
+                OperationType.Replace => property.ReplaceAsync,
+                OperationType.Test => property.TestAsync,
+                _ => throw new NotSupportedException($"The specified {nameof(OperationType)} '{operation.Op}' is not supported")
+            } ?? throw new NotSupportedException($"The specified JSON patch operation '{operation.Op}' is not supported for property at path '{operation.Path}'");
+            await operationDelegate(this.ServiceProvider, target, operation, cancellationToken).ConfigureAwait(false);
+        }
+
+        return target;
+    }
+
+}

--- a/src/Neuroglia.Data/NsmTree.cs
+++ b/src/Neuroglia.Data/NsmTree.cs
@@ -1,0 +1,81 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Data;
+
+/// <summary>
+/// Represents a <see href="https://en.wikipedia.org/wiki/Nested_set_model">Nested Set Model (NSM)</see> tree
+/// </summary>
+/// <typeparam name="T">The type of data to build a new <see cref="NsmTree{T}"/> for</typeparam>
+public class NsmTree<T>
+{
+
+    protected List<NsmTreeNode<T>>? _rootNodes;
+    /// <summary>
+    /// Gets a list containing the tree's root nodes, if any
+    /// </summary>
+    public virtual IReadOnlyCollection<NsmTreeNode<T>>? RootNodes => this._rootNodes?.AsReadOnly();
+
+    /// <summary>
+    /// Flattens the <see cref="NsmTree{T}"/>
+    /// </summary>
+    /// <returns>A new <see cref="IEnumerable{T}"/> containing all the <see cref="NsmTreeNode{T}"/> the tree is made out of</returns>
+    public virtual IEnumerable<NsmTreeNode<T>>? Flatten() => this.RootNodes?.SelectMany(n => n.Flatten());
+
+    /// <summary>
+    /// Builds a new <see cref="NsmTree{T}"/> using the specified hierarchy root items
+    /// </summary>
+    /// <param name="rootItems">The root items of the hierarchy to build a new <see cref="NsmTree{T}"/> for</param>
+    /// <param name="childrenResolver">A function used to resolve the children of a given item</param>
+    /// <returns>A new <see cref="NsmTree{T}"/></returns>
+    public static NsmTree<T> BuildFor(IEnumerable<T> rootItems, Func<T, IEnumerable<T>> childrenResolver)
+    {
+        if (rootItems == null || !rootItems.Any()) throw new ArgumentNullException(nameof(rootItems));
+        if (childrenResolver == null) throw new ArgumentNullException(nameof(childrenResolver));
+
+        var rootNode = new NsmTreeNode<T>(0, 0, 0, null, default!);
+        Populate(rootNode, rootItems, childrenResolver);
+
+        var tree = new NsmTree<T> { _rootNodes = rootNode.ChildNodes?.ToList() };
+        return tree;
+    }
+
+    /// <summary>
+    /// Populates a <see cref="NsmTreeNode{T}"/> using the specified collection of items
+    /// </summary>
+    /// <param name="parent">The <see cref="NsmTreeNode{T}"/> to populate</param>
+    /// <param name="items">The collection of items to populate the <see cref="NsmTreeNode{T}"/> with</param>
+    /// <param name="childrenResolver">A function used to resolve the children of a given item</param>
+    protected static void Populate(NsmTreeNode<T> parent, IEnumerable<T>? items, Func<T, IEnumerable<T>> childrenResolver)
+    {
+        if (parent == null) throw new ArgumentNullException(nameof(parent));
+        if (childrenResolver == null) throw new ArgumentNullException(nameof(childrenResolver));
+        if (items == null || !items.Any()) return;
+
+        var lastRight = parent.Left;
+        foreach (var item in items)
+        {
+            var left = lastRight + 1;
+            var right = left + 1;
+            var depth = parent.Left == 0 ? 0 : parent.Depth + 1;
+            var lineage = depth == 0 ? null : parent.Lineage + parent.Left.ToString("X8");
+            var node = new NsmTreeNode<T>(left, right, depth, lineage, item, parent);
+            parent.Append(node);
+            Populate(node, childrenResolver.Invoke(item), childrenResolver);
+            lastRight = node.Right;
+        }
+        parent.Freeze();
+
+    }
+
+}

--- a/src/Neuroglia.Data/NsmTreeNode.cs
+++ b/src/Neuroglia.Data/NsmTreeNode.cs
@@ -1,0 +1,113 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Data;
+
+/// <summary>
+/// Represents a <see cref="NsmTree"/> node
+/// </summary>
+public class NsmTreeNode<T>
+{
+
+    /// <summary>
+    /// Initializes a new <see cref="NsmTreeNode{T}"/>
+    /// </summary>
+    /// <param name="left">The <see cref="NsmTreeNode{T}"/>'s left number</param>
+    /// <param name="right">The <see cref="NsmTreeNode{T}"/>'s right number</param>
+    /// <param name="depth">The <see cref="NsmTreeNode{T}"/>'s depth</param>
+    /// <param name="lineage">The <see cref="NsmTreeNode{T}"/>'s lineage, which is a concatenation of the hexadecimal representation of the node's anecestors left</param>
+    /// <param name="value">The <see cref="NsmTreeNode{T}"/>'s value</param>
+    public NsmTreeNode(uint left, uint right, uint depth, string? lineage, T value, NsmTreeNode<T>? parent = null)
+    {
+        this.Left = left;
+        this.Right = right;
+        this.Depth = depth;
+        this.Lineage = lineage;
+        this.Value = value;
+        this.Parent = parent;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="NsmTreeNode{T}"/>'s left number
+    /// </summary>
+    public virtual uint Left { get; protected set; }
+
+    /// <summary>
+    /// Gets the <see cref="NsmTreeNode{T}"/>'s right number
+    /// </summary>
+    public virtual uint Right { get; protected set; }
+
+    /// <summary>
+    /// Gets the <see cref="NsmTreeNode{T}"/>'s depth
+    /// </summary>
+    public virtual uint Depth { get; protected set; }
+
+    /// <summary>
+    /// Gets the <see cref="NsmTreeNode{T}"/>'s lineage, which is a concatenation of the hexadecimal representation of the node's anecestors left
+    /// </summary>
+    public virtual string? Lineage { get; protected set; }
+
+    /// <summary>
+    /// Gets the <see cref="NsmTreeNode{T}"/>'s value
+    /// </summary>
+    public virtual T Value { get; protected set; }
+
+    /// <summary>
+    /// Gets the <see cref="NsmTreeNode{T}"/>'s parent, if any
+    /// </summary>
+    public virtual NsmTreeNode<T>? Parent { get; protected set; }
+
+    /// <summary>
+    /// Gets a value indicating whether or not the <see cref="NsmTreeNode{T}"/> is read-only
+    /// </summary>
+    public virtual bool ReadOnly { get; protected set; }
+
+    protected List<NsmTreeNode<T>>? _childNodes;
+    /// <summary>
+    /// Gets a list containing the node's children, if any
+    /// </summary>
+    public virtual IReadOnlyCollection<NsmTreeNode<T>>? ChildNodes => this._childNodes?.AsReadOnly();
+
+    /// <summary>
+    /// Appends the specified <see cref="NsmTreeNode{T}"/>
+    /// </summary>
+    /// <param name="node">The <see cref="NsmTreeNode{T}"/> to append</param>
+    public virtual void Append(NsmTreeNode<T> node)
+    {
+        if (node == null) throw new ArgumentNullException(nameof(node));
+        if (this.ReadOnly) throw new InvalidOperationException("Cannot update a node that is read-only");
+
+        this._childNodes ??= new();
+        this._childNodes.Add(node);
+
+        this.Right = node.Right + 1;
+        if(this.Parent != null) this.Parent.Right = this.Right + 1;
+    }
+
+    /// <summary>
+    /// Freezes the <see cref="NsmTreeNode{T}"/> by marking it as read-only
+    /// </summary>
+    public virtual void Freeze() => this.ReadOnly = true;
+
+    /// <summary>
+    /// Flattens the <see cref="NsmTree{T}"/>
+    /// </summary>
+    /// <returns>A new <see cref="IEnumerable{T}"/> containing all the <see cref="NsmTreeNode{T}"/> the tree is made out of</returns>
+    public virtual IEnumerable<NsmTreeNode<T>> Flatten()
+    {
+        yield return this;
+        if (this.ChildNodes == null) yield break;
+        foreach (var child in ChildNodes.SelectMany(n => n.Flatten())) yield return child;
+    }
+
+}

--- a/src/Neuroglia.Serialization.Abstractions/Json/InheritancePriorityJsonTypeInfoResolver.cs
+++ b/src/Neuroglia.Serialization.Abstractions/Json/InheritancePriorityJsonTypeInfoResolver.cs
@@ -1,0 +1,41 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Neuroglia.Serialization.Json;
+
+/// <summary>
+/// Represents a JsonTypeInfo resolver used to order properties according to their inheritance hierarchy
+/// </summary>
+public class InheritancePriorityJsonTypeInfoResolver 
+    : DefaultJsonTypeInfoResolver
+{
+
+    /// <inheritdoc/>
+    public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+    {
+        var typeInfo = base.GetTypeInfo(type, options);
+        var properties = type.GetProperties().ToDictionary(p => p.Name, p => p.DeclaringType!.GetAscendencyLevel(type));
+        if (typeInfo.Kind == JsonTypeInfoKind.Object)
+        {
+            foreach (var property in typeInfo.Properties.OrderBy(a => a.Name))
+            {
+                var offset = properties.First(kvp => kvp.Key.Equals(property.Name, StringComparison.OrdinalIgnoreCase)).Value;
+                property.Order -= offset;
+            }
+        }
+        return typeInfo;
+    }
+}

--- a/src/Neuroglia.Serialization.Abstractions/Json/JsonSerializer.cs
+++ b/src/Neuroglia.Serialization.Abstractions/Json/JsonSerializer.cs
@@ -34,6 +34,7 @@ public class JsonSerializer
     {
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault;
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.TypeInfoResolver = new InheritancePriorityJsonTypeInfoResolver();
         options.Converters.Add(new DictionaryConverter());
         options.Converters.Add(new ExpandoObjectConverter());
     };
@@ -128,10 +129,18 @@ public class JsonSerializer
     public virtual Task SerializeAsync(Stream stream, object graph, Type type, CancellationToken cancellationToken = default) => System.Text.Json.JsonSerializer.SerializeAsync(stream, graph, type, this.Options, cancellationToken);
 
     /// <inheritdoc/>
-    public virtual object? Deserialize(string input, Type type) => System.Text.Json.JsonSerializer.Deserialize(input, type, this.Options);
+    public virtual object? Deserialize(string json, Type type) => System.Text.Json.JsonSerializer.Deserialize(json, type, this.Options);
 
     /// <inheritdoc/>
     public virtual object? Deserialize(Stream stream, Type type) => System.Text.Json.JsonSerializer.Deserialize(stream, type, this.Options);
+
+    /// <summary>
+    /// Deserializes the specified <see cref="JsonElement"/>
+    /// </summary>
+    /// <param name="element">The <see cref="JsonElement"/> to deserialize</param>
+    /// <param name="type">The type to deserialize the specified <see cref="JsonElement"/> into</param>
+    /// <returns>The deserialized value</returns>
+    public virtual object? Deserialize(JsonElement element, Type type) => System.Text.Json.JsonSerializer.Deserialize(element, type, this.Options);
 
     /// <summary>
     /// Deserializes the specified <see cref="JsonElement"/>
@@ -152,10 +161,26 @@ public class JsonSerializer
     /// <summary>
     /// Deserializes the specified <see cref="JsonNode"/>
     /// </summary>
+    /// <param name="node">The <see cref="JsonNode"/> to deserialize</param>
+    /// <param name="type">The type to deserialize the specified <see cref="JsonNode"/> into</param>
+    /// <returns>The deserialized value</returns>
+    public virtual object? Deserialize(JsonNode node, Type type) => System.Text.Json.JsonSerializer.Deserialize(node, type, this.Options);
+
+    /// <summary>
+    /// Deserializes the specified <see cref="JsonNode"/>
+    /// </summary>
     /// <typeparam name="T">The type to deserialize the specified <see cref="JsonNode"/> into</typeparam>
     /// <param name="node">The <see cref="JsonNode"/> to deserialize</param>
     /// <returns>The deserialized value</returns>
     public virtual T? Deserialize<T>(JsonNode node) => System.Text.Json.JsonSerializer.Deserialize<T>(node, this.Options);
+
+    /// <summary>
+    /// Deserializes the specified JSON input
+    /// </summary>
+    /// <param name="buffer">The JSON input to deserialize</param>
+    /// <param name="type">The type to deserialize the specified JSON into</param>
+    /// <returns>The deserialized value</returns>
+    public virtual object? Deserialize(ReadOnlySpan<byte> buffer, Type type) => System.Text.Json.JsonSerializer.Deserialize(buffer, type, this.Options);
 
     /// <summary>
     /// Deserializes the specified JSON input

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/Expressions/Evaluators/JavaScriptExpressionEvaluatorTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/Expressions/Evaluators/JavaScriptExpressionEvaluatorTests.cs
@@ -172,7 +172,7 @@ public class JavaScriptExpressionEvaluatorTests
     public async Task Evaluate_String_Interpolation_ShouldWork()
     {
         //arrange
-        var data = NJsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-interpolation.input.json")))!;
+        var data = JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-interpolation.input.json")))!;
         var expression = File.ReadAllText(Path.Combine("Assets", "string-interpolation.expression.js.txt"));
 
         //act

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/Expressions/Evaluators/JavaScriptExpressionEvaluatorTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/Expressions/Evaluators/JavaScriptExpressionEvaluatorTests.cs
@@ -16,6 +16,7 @@ using Neuroglia.Data.Expressions;
 using Neuroglia.Data.Expressions.JavaScript;
 using Neuroglia.Data.Expressions.Services;
 using Neuroglia.Serialization;
+using Neuroglia.Serialization.Json;
 using System.Dynamic;
 
 namespace Neuroglia.UnitTests.Cases.Data.Expressions.Evaluators;
@@ -98,7 +99,7 @@ public class JavaScriptExpressionEvaluatorTests
     public async Task Evaluate_LargeData_ShouldWork()
     {
         //arrange
-        var data = Serialization.Json.JsonSerializer.Default.Deserialize<List<object>>(File.ReadAllText(Path.Combine("Assets", "dogs.json")))!;
+        var data = JsonSerializer.Default.Deserialize<List<object>>(File.ReadAllText(Path.Combine("Assets", "dogs.json")))!;
         var expression = "input.filter(i => i.category?.name === CONST.category)[0]";
         var args = new Dictionary<string, object>() { { "CONST", new { category = "Pugal" } } };
 
@@ -157,7 +158,7 @@ public class JavaScriptExpressionEvaluatorTests
     public async Task Evaluate_String_Concatenation_ShouldWork()
     {
         //arrange
-        var data = Serialization.Json.JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-concat.input.json")))!;
+        var data = JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-concat.input.json")))!;
         var expression = File.ReadAllText(Path.Combine("Assets", "string-concat.expression.js.txt"));
 
         //act
@@ -171,7 +172,7 @@ public class JavaScriptExpressionEvaluatorTests
     public async Task Evaluate_String_Interpolation_ShouldWork()
     {
         //arrange
-        var data = Serialization.Json.JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-interpolation.input.json")))!;
+        var data = NJsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-interpolation.input.json")))!;
         var expression = File.ReadAllText(Path.Combine("Assets", "string-interpolation.expression.js.txt"));
 
         //act
@@ -185,7 +186,7 @@ public class JavaScriptExpressionEvaluatorTests
     public async Task Evaluate_Complex_String_Substitution_ShouldWork()
     {
         //arrange
-        var data = Serialization.Json.JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-substitution.input.json")))!;
+        var data = JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-substitution.input.json")))!;
         var expression = File.ReadAllText(Path.Combine("Assets", "string-substitution.expression.js.txt"));
 
         //act
@@ -199,7 +200,7 @@ public class JavaScriptExpressionEvaluatorTests
     public async Task Evaluate_String_With_Escaped_Quotes_ShouldWork()
     {
         //arrange
-        var data = Serialization.Json.JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-quoted.input.json")))!;
+        var data = JsonSerializer.Default.Deserialize<ExpandoObject>(File.ReadAllText(Path.Combine("Assets", "string-quoted.input.json")))!;
         var expression = File.ReadAllText(Path.Combine("Assets", "string-quoted.expression.js.txt"));
 
         //act

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/NsmTreeTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/NsmTreeTests.cs
@@ -1,0 +1,156 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Neuroglia.Data;
+
+namespace Neuroglia.UnitTests.Cases.Data;
+
+public class NsmTreeTests
+{
+
+    [Fact]
+    public void Build_Tree_Should_Work()
+    {
+        //arrange
+        var categories = BuildCategories();
+
+        //act
+        var tree = NsmTree<Category>.BuildFor(categories.Where(c => string.IsNullOrWhiteSpace(c.ParentId)), c => GetChildrenOf(c, categories));
+
+        //assert
+        tree.Should().NotBeNull();
+        tree.RootNodes.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Flatten_Tree_Should_Work()
+    {
+        //arrange
+        var categories = BuildCategories();
+        var tree = NsmTree<Category>.BuildFor(categories.Where(c => string.IsNullOrWhiteSpace(c.ParentId)), c => GetChildrenOf(c, categories));
+
+        //act
+        var nodes = tree.Flatten();
+
+        //assert
+        nodes.Should().NotBeNull();
+        nodes.Should().HaveSameCount(categories);
+        nodes!.Select(n => n.Value).Should().BeEquivalentTo(categories);
+    }
+
+    [Fact]
+    public void Find_Node_Ancestor_Should_Work()
+    {
+        //arrange
+        var categories = BuildCategories();
+        var tree = NsmTree<Category>.BuildFor(categories.Where(c => string.IsNullOrWhiteSpace(c.ParentId)), c => GetChildrenOf(c, categories));
+        var nodes = tree.Flatten()!;
+        var fishNode = nodes.First(c => c.Value.Id == "fish");
+
+        //act
+        var ancestors = nodes.Where(n => !string.IsNullOrWhiteSpace(n.Lineage) && n.Lineage.StartsWith(fishNode.Lineage![..((int)(fishNode.Depth - 1) * 8)]) && n.Left < fishNode.Left && n.Right > fishNode.Right);
+
+        //assert
+        ancestors.Should().NotBeNull();
+        ancestors.Should().ContainSingle();
+        ancestors.First().Value.Id.Should().Be(fishNode.Value.ParentId);
+    }
+
+    [Fact]
+    public void Find_Node_Ancestors_Should_Work()
+    {
+        //arrange
+        var categories = BuildCategories();
+        var tree = NsmTree<Category>.BuildFor(categories.Where(c => string.IsNullOrWhiteSpace(c.ParentId)), c => GetChildrenOf(c, categories));
+        var nodes = tree.Flatten()!;
+        var node = nodes.First(c => c.Value.Id == "fish");
+
+        //act
+        var ancestors = nodes.Where(n => (string.IsNullOrWhiteSpace(n.Lineage) || n.Lineage.StartsWith(node.Lineage![..8])) && n.Left < node.Left && n.Right > node.Right);
+
+        //assert
+        ancestors.Should().NotBeNull();
+        ancestors.Should().HaveCount((int)node.Depth);
+    }
+
+    [Fact]
+    public void Find_Node_Direct_Descendants_Should_Work()
+    {
+        //arrange
+        var categories = BuildCategories();
+        var tree = NsmTree<Category>.BuildFor(categories.Where(c => string.IsNullOrWhiteSpace(c.ParentId)), c => GetChildrenOf(c, categories));
+        var nodes = tree.Flatten()!;
+        var node = nodes.First(c => c.Value.Id == "food");
+
+        //act
+        var descendants = nodes.Where(n => !string.IsNullOrWhiteSpace(n.Lineage) && n.Lineage.Length / 8 == node.Depth + 1 && n.Left > node.Left && n.Right < node.Right);
+
+        //assert
+        descendants.Should().NotBeNull();
+        descendants.Should().HaveSameCount(categories.Where(c => c.ParentId == node.Value.Id));
+    }
+
+    [Fact]
+    public void Find_Node_All_Descendants_Should_Work()
+    {
+        //arrange
+        var categories = BuildCategories();
+        var tree = NsmTree<Category>.BuildFor(categories.Where(c => string.IsNullOrWhiteSpace(c.ParentId)), c => GetChildrenOf(c, categories));
+        var nodes = tree.Flatten()!;
+        var node = nodes.First(c => c.Value.Id == "food");
+
+        //act
+        var descendants = nodes.Where(n => !string.IsNullOrWhiteSpace(n.Lineage) && n.Lineage.StartsWith(node.Lineage!) && n.Left > node.Left && n.Right < node.Right);
+
+        //assert
+        descendants.Should().NotBeNull();
+    }
+
+    static IEnumerable<Category> GetChildrenOf(Category category, IEnumerable<Category> categories) => categories.Where(c => c.ParentId == category.Id);
+
+    static IEnumerable<Category> BuildCategories()
+    {
+        var products = new Category("products");
+        var drinks = new Category("drinks", products.Id);
+        var soda = new Category("soda", drinks.Id);
+        var juices = new Category("juices", drinks.Id);
+        var freshJuices = new Category("fresh juices", juices.Id);
+        var bottledJuices = new Category("bottled juices", juices.Id);
+        var waters = new Category("waters", drinks.Id);
+        var alcohol = new Category("alcohol", drinks.Id);
+        var food = new Category("food", products.Id);
+        var starters = new Category("starters", food.Id);
+        var mainCourses = new Category("main courses", food.Id);
+        var meat = new Category("meat", mainCourses.Id);
+        var fish = new Category("fish", mainCourses.Id);
+        var vegetarian = new Category("vegetarian", mainCourses.Id);
+        var desserts = new Category("desserts", food.Id);
+        return new List<Category>() { products, drinks, soda, juices, freshJuices, bottledJuices, waters, alcohol, food, starters, mainCourses, meat, fish, vegetarian, desserts };
+    }
+
+    class Category
+    {
+
+        public Category(string id, string? parentId = null)
+        {
+            this.Id = id;
+            this.ParentId = parentId;
+        }
+
+        public string Id { get; }
+
+        public string? ParentId { get; }
+
+    }
+
+}

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/PatchModel/ReflectionBasedJsonPatchHandlerTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/PatchModel/ReflectionBasedJsonPatchHandlerTests.cs
@@ -1,0 +1,201 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Json.Patch;
+using Json.Pointer;
+using Microsoft.Extensions.DependencyInjection;
+using Neuroglia.Data;
+using Neuroglia.Data.PatchModel;
+using Neuroglia.Data.PatchModel.Services;
+using Neuroglia.Serialization.Json;
+
+namespace Neuroglia.UnitTests.Cases.Data.PatchModel;
+
+public class ReflectionBasedJsonPatchHandlerTests
+{
+
+    protected IPatchHandler PatchHandler { get; } = new ReflectionBasedJsonPatchHandler(new ServiceCollection().BuildServiceProvider());
+
+    [Fact]
+    public async Task Patch_Aggregate_Should_Work()
+    {
+        //arrange
+        var tagToRemove = "Old Fake Tag To Remove";
+        var product = new ProductAggregate("Fake Name", "Fake Description", tags: new string[] { tagToRemove });
+        var updatedName = "Updated Fake Product Name";
+        var updatedDescription = "Updated Fake Product Description";
+        var newTag = "New Fake Tag";
+        var patchOperations = new List<PatchOperation>()
+        {
+            PatchOperation.Replace(JsonPointer.Create<ProductState>(p => p.Name), JsonSerializer.Default.SerializeToNode(updatedName)),
+            PatchOperation.Replace(JsonPointer.Create<ProductState>(p => p.Description!), JsonSerializer.Default.SerializeToNode(updatedDescription)),
+            PatchOperation.Add(JsonPointer.Create<ProductState>(p => p.Tags), JsonSerializer.Default.SerializeToNode(newTag)),
+            PatchOperation.Remove(JsonPointer.Create<ProductState>(p => p.Tags).Combine(JsonPointer.Parse("/0"))),
+            PatchOperation.Test(JsonPointer.Create<ProductState>(p => p.StateVersion), JsonSerializer.Default.SerializeToNode(0))
+        };
+        var patch = new JsonPatch(patchOperations);
+
+        //act
+        product = await this.PatchHandler.ApplyPatchAsync(patch, product);
+
+        //assert
+        product!.State.Name.Should().Be(updatedName);
+        product.State.Description.Should().Be(updatedDescription);
+        product.State.Tags.Should().ContainSingle();
+        product.State.Tags.Should().Contain(newTag);
+    }
+
+    class Product
+    {
+
+        public Product()
+        {
+            this.Name = "Unamed";
+            this._activeTags.Add("active");
+            this.Contacts.Add("contact-to-remove-1");
+            this.Contacts.Add("contact-to-remove-2");
+            this.Contacts.Add("contact-to-remove-3");
+        }
+
+        public string Name { get; protected set; } = null!;
+
+        public string? Description { get; set; }
+
+        private List<Category> _categories = new();
+        public IReadOnlyCollection<Category> Categories => this._categories.AsReadOnly();
+
+        private List<string> _activeTags = new();
+        public IReadOnlyCollection<string> ActiveTags => this._activeTags.AsReadOnly();
+
+        private List<string> _retiredTags = new();
+        public IReadOnlyCollection<string> RetiredTags => this._retiredTags.AsReadOnly();
+
+        public List<string> Contacts { get; set; } = new();
+
+        public List<string>? ContactsToRemove { get; set; }
+
+        [JsonPatchOperation(JsonPatchOperationType.Add | JsonPatchOperationType.Replace, nameof(Name))]
+        public virtual void SetName(string name)
+        {
+            this.Name = name;
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Add, nameof(Categories))]
+        public virtual void AddCategory(Category category, int? index = null)
+        {
+            if (index.HasValue) this._categories.Insert(index.Value, category);
+            else this._categories.Add(category);
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(Categories))]
+        public virtual void ReplaceCategory(Category category, int index)
+        {
+
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Remove, nameof(Categories))]
+        public virtual void RemoveCategory(int index)
+        {
+            this._categories.RemoveAt(index);
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Copy, nameof(ActiveTags))]
+        public void AddRetiredTags(IEnumerable<string>? tags)
+        {
+            if (tags == null) return;
+            this._retiredTags.AddRange(tags);
+        }
+
+    }
+
+    class Category
+        : Entity<string>
+    {
+
+        public Category(string name)
+            : base(Guid.NewGuid().ToString("N"))
+        {
+            this.Name = name;
+        }
+
+        public string Name { get; set; }
+
+    }
+
+    class ProductAggregate
+        : AggregateRoot<string, ProductState>
+    {
+
+        public ProductAggregate(string name, string? description = null, IEnumerable<string>? tags = null)
+        {
+            this.State.Name = name;
+            this.State.Description = description;
+            if (tags != null) this.State._tags = tags.ToList();
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(ProductState.Name))]
+        public void SetName(string name)
+        {
+            this.State.Name = name;
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(ProductState.Description))]
+        public void SetDescription(string description)
+        {
+            this.State.Description = description;
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Add, nameof(ProductState.Categories), ReferencedType = typeof(Category))]
+        public void AddCategory(Category category)
+        {
+            this.State._categories.Add(category.Id);
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Add, nameof(ProductState.Categories), ReferencedType = typeof(Category))]
+        public void RemoveCategory(int index)
+        {
+            this.State._categories.RemoveAt(index);
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Add, nameof(ProductState.Tags))]
+        public void AddTag(string tag, int? index = null)
+        {
+            if (index.HasValue) this.State._tags.Insert(index.Value, tag);
+            else this.State._tags.Add(tag);
+        }
+
+        [JsonPatchOperation(JsonPatchOperationType.Remove, nameof(ProductState.Tags))]
+        public void RemoveTag(int index)
+        {
+            this.State._tags.RemoveAt(index);
+        }
+
+    }
+
+    record ProductState
+        : AggregateState<string>
+    {
+
+        public string Name { get; internal protected set; }
+
+        public string? Description { get; internal protected set; }
+
+        internal List<string> _categories = new();
+        public IReadOnlyCollection<string> Categories => this._categories.AsReadOnly();
+
+        internal List<string> _tags = new();
+        public IReadOnlyCollection<string> Tags => this._tags.AsReadOnly();
+
+    }
+
+}

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/PatchModel/ReflectionBasedJsonPatchHandlerTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Data/PatchModel/ReflectionBasedJsonPatchHandlerTests.cs
@@ -71,13 +71,13 @@ public class ReflectionBasedJsonPatchHandlerTests
 
         public string? Description { get; set; }
 
-        private List<Category> _categories = new();
+        private readonly List<Category> _categories = new();
         public IReadOnlyCollection<Category> Categories => this._categories.AsReadOnly();
 
-        private List<string> _activeTags = new();
+        private readonly List<string> _activeTags = new();
         public IReadOnlyCollection<string> ActiveTags => this._activeTags.AsReadOnly();
 
-        private List<string> _retiredTags = new();
+        private readonly List<string> _retiredTags = new();
         public IReadOnlyCollection<string> RetiredTags => this._retiredTags.AsReadOnly();
 
         public List<string> Contacts { get; set; } = new();
@@ -186,7 +186,7 @@ public class ReflectionBasedJsonPatchHandlerTests
         : AggregateState<string>
     {
 
-        public string Name { get; internal protected set; }
+        public string Name { get; internal protected set; } = null!;
 
         public string? Description { get; internal protected set; }
 

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
@@ -33,4 +33,30 @@ public class JsonSerializerTests
 
     }
 
+    abstract class Mammal
+    {
+
+        protected Mammal(string family)
+        {
+            this.Family = family;
+        }
+
+        public string Family { get; protected set; }
+
+    }
+
+    class Dog
+        : Mammal
+    {
+
+        public Dog(string breed)
+            : base("Canidae")
+        {
+            this.Breed = breed;
+        }
+
+        public string Breed { get; protected set; }
+
+    }
+
 }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
@@ -29,7 +29,7 @@ public class JsonSerializerTests
         var deserialized = JsonSerializer.Default.Deserialize<IDictionary<string, object>>(serialized)!;
 
         //assert
-        deserialized.ElementAt(0).Key.Should().BeEquivalentTo("name");
+        deserialized.ElementAt(0).Key.Should().BeEquivalentTo(nameof(Mammal.Family));
 
     }
 

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Neuroglia.Serialization.Json;
+
+namespace Neuroglia.UnitTests.Cases.Serialization;
+
+public class JsonSerializerTests
+{
+
+    [Fact]
+    public void Serialize_Should_Work()
+    {
+        //arrange
+        var dog = new Dog("Belgian Shepperd");
+
+        //act
+        var serialized = JsonSerializer.Default.SerializeToText(dog);
+        var deserialized = JsonSerializer.Default.Deserialize<IDictionary<string, object>>(serialized)!;
+
+        //assert
+        deserialized.ElementAt(0).Key.Should().BeEquivalentTo("name");
+
+    }
+
+}

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/PersonCreatedDomainEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/PersonCreatedDomainEvent.cs
@@ -22,8 +22,8 @@ public class PersonCreatedDomainEvent
 
     protected PersonCreatedDomainEvent() { }
 
-    public PersonCreatedDomainEvent(Guid personId, string firstName, string lastName)
-        : base(personId)
+    public PersonCreatedDomainEvent(Guid aggregateId, string firstName, string lastName)
+        : base(aggregateId)
     {
         this.FirstName = firstName;
         this.LastName = lastName;

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/PersonFirstNameChangedDomainEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/PersonFirstNameChangedDomainEvent.cs
@@ -20,8 +20,8 @@ public class PersonFirstNameChangedDomainEvent
 {
 
     protected PersonFirstNameChangedDomainEvent() { }
-    public PersonFirstNameChangedDomainEvent(Guid personId, string firstName)
-        : base(personId)
+    public PersonFirstNameChangedDomainEvent(Guid aggregateId, string firstName)
+        : base(aggregateId)
     {
         this.FirstName = firstName;
     }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/PersonLastNameChangedDomainEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/PersonLastNameChangedDomainEvent.cs
@@ -21,8 +21,8 @@ public class PersonLastNameChangedDomainEvent
 
     protected PersonLastNameChangedDomainEvent() { }
 
-    public PersonLastNameChangedDomainEvent(Guid personId, string lastName)
-        : base(personId)
+    public PersonLastNameChangedDomainEvent(Guid aggregateId, string lastName)
+        : base(aggregateId)
     {
         this.LastName = lastName;
     }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserCreatedEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserCreatedEvent.cs
@@ -21,8 +21,8 @@ internal class UserCreatedEvent
 
     protected UserCreatedEvent() { }
 
-    public UserCreatedEvent(string id, string firstName, string lastName, string email)
-        : base(id)
+    public UserCreatedEvent(string aggregateId, string firstName, string lastName, string email)
+        : base(aggregateId)
     {
         this.FirstName = firstName;
         this.LastName = lastName;

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserCreatedEventV2.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserCreatedEventV2.cs
@@ -21,8 +21,8 @@ internal class UserCreatedEventV2
 
     protected UserCreatedEventV2() { }
 
-    public UserCreatedEventV2(string id, string firstName, string lastName, string email, Address address)
-        : base(id)
+    public UserCreatedEventV2(string aggregateId, string firstName, string lastName, string email, Address address)
+        : base(aggregateId)
     {
         this.FirstName = firstName;
         this.LastName = lastName;

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserCreatedEventV3.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserCreatedEventV3.cs
@@ -21,8 +21,8 @@ internal class UserCreatedEventV3
 
     protected UserCreatedEventV3() { }
 
-    public UserCreatedEventV3(string id, string firstName, string lastName, string email, Address address, string phoneNumber)
-        : base(id)
+    public UserCreatedEventV3(string aggregateId, string firstName, string lastName, string email, Address address, string phoneNumber)
+        : base(aggregateId)
     {
         this.FirstName = firstName;
         this.LastName = lastName;

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserEmailValidatedEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserEmailValidatedEvent.cs
@@ -21,6 +21,6 @@ internal class UserEmailValidatedEvent
 
     protected UserEmailValidatedEvent() { }
 
-    public UserEmailValidatedEvent(string id) : base(id) { }
+    public UserEmailValidatedEvent(string aggregateId) : base(aggregateId) { }
 
 }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserLoggedInEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserLoggedInEvent.cs
@@ -21,6 +21,6 @@ internal class UserLoggedInEvent
 
     protected UserLoggedInEvent() { }
 
-    public UserLoggedInEvent(string id) : base(id) { }
+    public UserLoggedInEvent(string aggregateId) : base(aggregateId) { }
 
 }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserLoggedOutEvent.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Events/UserLoggedOutEvent.cs
@@ -21,6 +21,6 @@ internal class UserLoggedOutEvent
 
     protected UserLoggedOutEvent() { }
 
-    public UserLoggedOutEvent(string id) : base(id) { }
+    public UserLoggedOutEvent(string aggregateId) : base(aggregateId) { }
 
 }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Person.cs
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests/Data/Person.cs
@@ -13,7 +13,8 @@
 
 using Json.Patch;
 using Neuroglia.Data;
-using Neuroglia.Data.PatchModel.Attributes;
+using Neuroglia.Data.PatchModel;
+using Neuroglia.Data.PatchModel.Services;
 using Neuroglia.UnitTests.Data.Events;
 
 namespace Neuroglia.UnitTests.Data;
@@ -30,7 +31,7 @@ public class Person
 
     public Person(string firstName, string lastName) : this(Guid.NewGuid(), firstName, lastName) { }
 
-    [JsonPatchOperation(OperationType.Replace, nameof(PersonStateV1.FirstName))]
+    [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(PersonStateV1.FirstName))]
     public virtual bool SetFirstName(string firstName)
     {
         if (this.State.FirstName == firstName) return false;
@@ -38,7 +39,7 @@ public class Person
         return true;
     }
 
-    [JsonPatchOperation(OperationType.Replace, nameof(PersonStateV1.LastName))]
+    [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(PersonStateV1.LastName))]
     public virtual bool SetLastName(string lastName)
     {
         if (this.State.LastName == lastName) return false;
@@ -46,51 +47,51 @@ public class Person
         return true;
     }
 
-    [JsonPatchOperation(OperationType.Add, nameof(PersonStateV1.Addresses))]
+    [JsonPatchOperation(JsonPatchOperationType.Add, nameof(PersonStateV1.Addresses))]
     public virtual void AddAddress(string address)
     {
         this.State.Addresses.Add(address);
     }
 
-    [JsonPatchOperation(OperationType.Add, nameof(PersonStateV1.FriendsIds), ReferencedType = typeof(Person))]
+    [JsonPatchOperation(JsonPatchOperationType.Add, nameof(PersonStateV1.FriendsIds), ReferencedType = typeof(Person))]
     public virtual void AddFriend(Person friend)
     {
         this.State.FriendsIds.Add(friend.Id);
     }
 
-    [JsonPatchOperation(OperationType.Remove, nameof(PersonStateV1.FriendsIds), ReferencedType = typeof(Person))]
+    [JsonPatchOperation(JsonPatchOperationType.Remove, nameof(PersonStateV1.FriendsIds), ReferencedType = typeof(Person))]
     public virtual void RemoveFriend(Person friend)
     {
         this.State.FriendsIds.Remove(friend.Id);
     }
 
-    [JsonPatchOperation(OperationType.Replace, nameof(PersonStateV1.Birthday))]
+    [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(PersonStateV1.Birthday))]
     public virtual void SetBirthday(DateTime birthDay)
     {
         this.State.Birthday = birthDay;
     }
 
-    [JsonPatchOperation(OperationType.Add, nameof(PersonStateV1.Contacts))]
+    [JsonPatchOperation(JsonPatchOperationType.Add, nameof(PersonStateV1.Contacts))]
     public virtual void AddContact(Contact contact)
     {
         this.State.Contacts.Add(contact);
     }
 
-    [JsonPatchOperation(OperationType.Replace, nameof(PersonStateV1.Contacts) + "/" + nameof(Contact.Tel))]
+    [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(PersonStateV1.Contacts) + "/" + nameof(Contact.Tel))]
     public virtual void UpdateContactTelephoneNumber(Guid contactId, string tel)
     {
         var contact = this.State.Contacts.First(c => c.Id == contactId);
         contact.Tel = tel;
     }
 
-    [JsonPatchOperation(OperationType.Replace, nameof(PersonStateV1.Traits) + "/" + nameof(PersonTrait.Name))]
+    [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(PersonStateV1.Traits) + "/" + nameof(PersonTrait.Name))]
     public virtual void SetPreferenceName(Guid id, string name)
     {
         var trait = this.State.Traits.First(t => t.Id == id);
         trait.Name = name;
     }
 
-    [JsonPatchOperation(OperationType.Replace, nameof(PersonStateV1.Traits) + "/" + nameof(PersonTrait.Value))]
+    [JsonPatchOperation(JsonPatchOperationType.Replace, nameof(PersonStateV1.Traits) + "/" + nameof(PersonTrait.Value))]
     public virtual void SetPreferenceValue(Guid id, decimal value)
     {
         var trait = this.State.Traits.First(t => t.Id == id);


### PR DESCRIPTION
- Adds a Nested Set Model tree implementation
- Adds the RelfectionBasedJsonPatchHandler, which allows applying JSON Patches to complex types and aggregates
- Adds multiple extensions for ICollections, IEnumerables, ILists, MemberInfos and Types
- Fixes the EventAggregator to properly set the state version of IAggregate implementations
- Adds non-generic overloads to a couple of methods
- Adds the InheritancePriorityJsonTypeInfoResolver to give precedence to inherited members according to their hieararchical level during ordering