### PR TITLE
Fixed the WhenNullReference Guard Clause to use the camel-cased name of the reference type instead of its full name

### DIFF
--- a/src/Neuroglia.Data.Guards/GuardClause.cs
+++ b/src/Neuroglia.Data.Guards/GuardClause.cs
@@ -48,7 +48,7 @@ public class GuardClause<T>(T? value, string? argumentName = null)
     }
 
     /// <inheritdoc/>
-    public IGuardClause<T> WhenNullReference<TKey>(TKey key, string keyName) => this.WhenNullReference(key, new GuardException(StringFormatter.NamedFormat(GuardExceptionMessages.when_null_reference, new { type = typeof(T), key, keyName }), this.ArgumentName));
+    public IGuardClause<T> WhenNullReference<TKey>(TKey key, string keyName) => this.WhenNullReference(key, new GuardException(StringFormatter.NamedFormat(GuardExceptionMessages.when_null_reference, new { type = typeof(T).Name.ToCamelCase(), key, keyName }), this.ArgumentName));
 
     /// <inheritdoc/>
     public IGuardClause<T> WhenNullReference<TKey>(TKey key, GuardException ex)

--- a/src/Neuroglia.Mediation.AspNetCore/Extensions/ControllerBaseExtensions.cs
+++ b/src/Neuroglia.Mediation.AspNetCore/Extensions/ControllerBaseExtensions.cs
@@ -47,7 +47,7 @@ public static class ControllerBaseExtensions
             if (result.Status == (int)HttpStatusCode.Forbidden) return controller.StatusCode((int)HttpStatusCode.Forbidden);
             if (result.Status == (int)HttpStatusCode.BadRequest)
             {
-                result.Errors?.ToList().ForEach(e => controller.ModelState.AddModelError(e.Title!, e.Detail!));
+                result.Errors?.ToList().SelectMany(e => e.Errors == null ? new Dictionary<string, string[]>() { { e.Title!, new string[] { e.Detail! } } }.ToList() : e.Errors.ToList()).ToList().ForEach(e => controller.ModelState.AddModelError(e.Key, string.Join(Environment.NewLine, e.Value)));
                 return controller.ValidationProblem(controller.ModelState);
             }
             if (result.Status == (int)HttpStatusCode.NotFound)

--- a/src/Neuroglia.Mediation/Services/GuardExceptionHandlingMiddleware.cs
+++ b/src/Neuroglia.Mediation/Services/GuardExceptionHandlingMiddleware.cs
@@ -62,7 +62,7 @@ public class GuardExceptionHandlingMiddleware<TRequest, TResult>
             result = default!;
             return false;
         }
-        result = (TResult)Activator.CreateInstance(responseType, resultCode, errors)!;
+        result = (TResult)Activator.CreateInstance(responseType, resultCode, null, errors)!;
         return true;
     }
 


### PR DESCRIPTION
- Fixes the WhenNullReference Guard Clause to use the camel-cased name of the reference type instead of its full name
- Fixes the GuardExceptionHandlingMiddleware to use the proper amount of arguments when initializing a new OperationResult
- Fixes the AspNetCore's ControllerBaseExtensions to properly transform the ModelState based on the OperationResult's errors, if any