### PR TITLE
Fixed the CloudEventMiddleware to used the IAsyncSerializer interface if present

### DIFF
--- a/src/Neuroglia.Eventing.CloudEvents.AspNetCore/CloudEventMiddleware.cs
+++ b/src/Neuroglia.Eventing.CloudEvents.AspNetCore/CloudEventMiddleware.cs
@@ -55,7 +55,7 @@ public class CloudEventMiddleware
         try
         {
             var serializer = context.RequestServices.GetRequiredService<IJsonSerializer>();
-            var e = serializer.Deserialize<CloudEvent>(context.Request.Body)!;
+            var e = serializer is IAsyncSerializer asyncSerializer ? await asyncSerializer.DeserializeAsync<CloudEvent>(context.Request.Body) : serializer.Deserialize<CloudEvent>(context.Request.Body)!;
             cloudEventBus.InputStream.OnNext(e);
             context.Response.StatusCode = (int)HttpStatusCode.Accepted;
         }

--- a/src/Neuroglia.Eventing.CloudEvents.Infrastructure/Services/CloudEventIngestor.cs
+++ b/src/Neuroglia.Eventing.CloudEvents.Infrastructure/Services/CloudEventIngestor.cs
@@ -104,10 +104,10 @@ public class CloudEventIngestor
                 this.Logger.LogWarning("The cloud event of type '{cloudEventType}' with id '{cloudEventId}' does not have data, and will therefore not be ingested, but will be acked.", e.Type, e.Id);
                 return;
             }
-            else if (ingestionConfiguration.DataType.IsAssignableFrom(notification.GetType())) notification = this.Serializer.Convert(notification, ingestionConfiguration.DataType);
+            else if (ingestionConfiguration.DataType != notification.GetType()) notification = this.Serializer.Convert(notification, ingestionConfiguration.DataType);
             await mediator.PublishAsync((dynamic)notification!, cancellationToken).ConfigureAwait(false);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             this.Logger.LogError("Failed to ingest the cloud event of type '{cloudEventType}' with id '{cloudEventId}': {ex}", e.Type, e.Id, ex);
         }

--- a/src/Neuroglia.Serialization.Abstractions/Extensions/ISerializerExtensions.cs
+++ b/src/Neuroglia.Serialization.Abstractions/Extensions/ISerializerExtensions.cs
@@ -73,6 +73,16 @@ public static class ISerializerExtensions
     }
 
     /// <summary>
+    /// Deserializes the value written on the specified <see cref="Stream"/>
+    /// </summary>
+    /// <typeparam name="T">The value's expected type</typeparam>
+    /// <param name="serializer">The extended <see cref="ISerializer"/></param>
+    /// <param name="stream">The <see cref="Stream"/> the value to deserialize has been written to</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>The deserialized value, if any</returns>
+    public static async Task<T?> DeserializeAsync<T>(this IAsyncSerializer serializer, Stream stream, CancellationToken cancellationToken = default) => (T?)await serializer.DeserializeAsync(stream, typeof(T), cancellationToken);
+
+    /// <summary>
     /// Converts the specified value into a new instance of the target type
     /// </summary>
     /// <param name="serializer">The extended <see cref="ISerializer"/></param>

--- a/src/Neuroglia.Serialization.Abstractions/Json/InheritancePriorityJsonTypeInfoResolver.cs
+++ b/src/Neuroglia.Serialization.Abstractions/Json/InheritancePriorityJsonTypeInfoResolver.cs
@@ -28,7 +28,7 @@ public class InheritancePriorityJsonTypeInfoResolver
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
     {
         var typeInfo = base.GetTypeInfo(type, options);
-        var properties = type.GetProperties().ToDictionary(p => p.TryGetCustomAttribute<JsonPropertyNameAttribute>(out var propertyNameAttribute) && propertyNameAttribute != null ? propertyNameAttribute.Name : p.Name, p => p.DeclaringType!.GetAscendencyLevel(type));
+        var properties = type.GetProperties().Where(p => !p.TryGetCustomAttribute<JsonIgnoreAttribute>(out _)).ToDictionary(p => p.TryGetCustomAttribute<JsonPropertyNameAttribute>(out var propertyNameAttribute) && propertyNameAttribute != null ? propertyNameAttribute.Name : p.Name, p => p.DeclaringType!.GetAscendencyLevel(type));
         if (typeInfo.Kind == JsonTypeInfoKind.Object)
         {
             foreach (var property in typeInfo.Properties.OrderBy(a => a.Name))


### PR DESCRIPTION
- Fixes the CloudEventMiddleware to used the IAsyncSerializer interface if present
- Fixes the CloudEventIngestor by properly checking cloud events data type
- Fixes the ISerializerExtensions by adding a new DeserializeAsync generic extension
- Fixes the InheritancePrioprityJsonTypeResolver by excluding properties marked with the JsonIgnoreAttribute