### PR TITLE
Fixed all Repository implementations to ensure not throwing when attempting to retrieve a non-existing entity

### DIFF
--- a/Neuroglia Framework.sln
+++ b/Neuroglia Framework.sln
@@ -94,7 +94,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neuroglia.Data.Guards", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neuroglia.UnitTests", "test\Neuroglia.UnitTests\Neuroglia.UnitTests.csproj", "{63922ABE-916D-4A4D-A3E1-8162BEED060E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neuroglia.Mediation.Abstractions", "src\Neuroglia.Mediation.Abstractions\Neuroglia.Mediation.Abstractions.csproj", "{23AEEAC4-03C7-4E6F-AB74-26588908AAB9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neuroglia.Mediation.Abstractions", "src\Neuroglia.Mediation.Abstractions\Neuroglia.Mediation.Abstractions.csproj", "{23AEEAC4-03C7-4E6F-AB74-26588908AAB9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Configuration/EventStoreOptions.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Configuration/EventStoreOptions.cs
@@ -23,6 +23,11 @@ public class EventStoreOptions
 {
 
     /// <summary>
+    /// Gets/sets the name of the database to use, if any
+    /// </summary>
+    public string? DatabaseName { get; set; }
+
+    /// <summary>
     /// Gets/sets the type of <see cref="ISerializer"/> to use to serialize and deserialize events. If not set, will use the first registered <see cref="ISerializer"/>
     /// </summary>
     public Type? SerializerType { get; set; }

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Services/EventStoreOptionsBuilder.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Services/EventStoreOptionsBuilder.cs
@@ -37,6 +37,13 @@ public class EventStoreOptionsBuilder
     }
 
     /// <inheritdoc/>
+    public virtual IEventStoreOptionsBuilder UseDatabase(string databaseName)
+    {
+        this.Options.DatabaseName = databaseName;
+        return this;
+    }
+
+    /// <inheritdoc/>
     public virtual EventStoreOptions Build() => this.Options;
 
 }

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Services/Interfaces/IEventStoreOptionsBuilder.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Services/Interfaces/IEventStoreOptionsBuilder.cs
@@ -31,6 +31,13 @@ public interface IEventStoreOptionsBuilder
         where TSerializer : class, ISerializer;
 
     /// <summary>
+    /// Uses the specified database
+    /// </summary>
+    /// <param name="databaseName">The name of the database to use</param>
+    /// <returns>The configured <see cref="IEventStoreOptionsBuilder"/></returns>
+    IEventStoreOptionsBuilder UseDatabase(string databaseName);
+
+    /// <summary>
     /// Builds the <see cref="EventStoreOptions"/>
     /// </summary>
     /// <returns>A new <see cref="EventStoreOptions"/></returns>

--- a/src/Neuroglia.Data.Infrastructure.Mongo/Neuroglia.Data.Infrastructure.Mongo.csproj
+++ b/src/Neuroglia.Data.Infrastructure.Mongo/Neuroglia.Data.Infrastructure.Mongo.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Neuroglia.Data.Guards\Neuroglia.Data.Guards.csproj" />
     <ProjectReference Include="..\Neuroglia.Data.Infrastructure.Abstractions\Neuroglia.Data.Infrastructure.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Neuroglia.Data.PatchModel/Neuroglia.Data.PatchModel.csproj
+++ b/src/Neuroglia.Data.PatchModel/Neuroglia.Data.PatchModel.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="JsonCons.Utilities" Version="1.0.0" />
     <PackageReference Include="JsonPatch.Net" Version="2.1.0" />
-    <PackageReference Include="JsonSchema.Net" Version="5.3.1" />
+    <PackageReference Include="JsonSchema.Net" Version="5.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
+++ b/src/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="FluentValidation" Version="11.8.0" />
+	<PackageReference Include="FluentValidation" Version="11.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Neuroglia.Plugins/Neuroglia.Plugins.csproj
+++ b/src/Neuroglia.Plugins/Neuroglia.Plugins.csproj
@@ -37,8 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.7.0" />
-	<PackageReference Include="NuGet.Protocol" Version="6.7.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.8.0" />
+	<PackageReference Include="NuGet.Protocol" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Neuroglia.UnitTests/Cases/Data/Infrastructure/RepositoryTestsBase.cs
+++ b/test/Neuroglia.UnitTests/Cases/Data/Infrastructure/RepositoryTestsBase.cs
@@ -13,6 +13,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Neuroglia.Data.Guards;
 using Neuroglia.Data.Infrastructure.Services;
 
 namespace Neuroglia.UnitTests.Cases.Data.Infrastructure;
@@ -59,7 +60,7 @@ public abstract class RepositoryTestsBase
     }
 
     [Fact, Priority(2)]
-    public async Task Contains_Should_Work()
+    public async Task Contains_Existing_Should_Work()
     {
         //arrange
         var user = await Repository.AddAsync(User.Create());
@@ -73,7 +74,17 @@ public abstract class RepositoryTestsBase
     }
 
     [Fact, Priority(3)]
-    public async Task Get_Should_Work()
+    public async Task Contains_NonExisting_Should_Work()
+    {
+        //act
+        var result = await Repository.ContainsAsync(Guid.NewGuid().ToString());
+
+        //assert
+        result.Should().BeFalse();
+    }
+
+    [Fact, Priority(4)]
+    public async Task Get_Existing_Should_Work()
     {
         //arrange
         var user = await Repository.AddAsync(User.Create());
@@ -89,8 +100,18 @@ public abstract class RepositoryTestsBase
         result.State.Email?.Should().Be(user.State.Email);
     }
 
-    [Fact, Priority(4)]
-    public async Task Update_Should_Work()
+    [Fact, Priority(5)]
+    public async Task Get_NonExisting_Should_Work()
+    {
+        //act
+        var result = await Repository.GetAsync(Guid.NewGuid().ToString());
+
+        //assert
+        result.Should().BeNull();
+    }
+
+    [Fact, Priority(6)]
+    public async Task Update_Existing_Should_Work()
     {
         //arrange
         var user = User.Create();
@@ -106,8 +127,22 @@ public abstract class RepositoryTestsBase
         result.State.EmailVerified.Should().BeTrue();
     }
 
-    [Fact, Priority(5)]
-    public async Task Remove_Should_Work()
+    [Fact, Priority(7)]
+    public async Task Update_NonExisting_Should_Throw()
+    {
+        //arrange
+        var user = User.Create();
+
+        //act
+        user.VerifyEmail();
+        var action = () => Repository.UpdateAsync(user);
+
+        //assert
+        await action.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact, Priority(8)]
+    public async Task Remove_Existing_Should_Work()
     {
         //arrange
         var user = await Repository.AddAsync(User.Create());
@@ -120,6 +155,16 @@ public abstract class RepositoryTestsBase
         //assert
         result.Should().BeTrue();
         contains.Should().BeFalse();
+    }
+
+    [Fact, Priority(9)]
+    public async Task Remove_NonExisting_Should_Throw()
+    {
+        //act
+        var result = await Repository.RemoveAsync(Guid.NewGuid().ToString());
+
+        //assert
+        result.Should().BeFalse();
     }
 
 }

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests.csproj
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests.csproj
@@ -1,17 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
@@ -20,8 +21,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="Testcontainers" Version="3.6.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests.csproj
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests.csproj
@@ -6,8 +6,6 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Fixes all Repository implementations to ensure not throwing when attempting to retrieve a non-existing entity
- Adds options to configure the name of the database an event store uses
- Fixes the ESEventStore to prefix streams with the name of the database it uses, if any
- Updates solution packages
