### PR TITLE
Fixed the IDomainEvent interface and implementation to include an AggregateVersion property

### DIFF
--- a/src/Neuroglia.Data/AggregateRoot.cs
+++ b/src/Neuroglia.Data/AggregateRoot.cs
@@ -61,6 +61,9 @@ public abstract class AggregateRoot<TKey, TState>
         where TEvent : IDomainEvent
     {
         if (e == null) throw new ArgumentNullException(nameof(e));
+
+        if (e is DomainEvent<TKey> domainEvent) domainEvent.AggregateVersion = this.State.StateVersion + (ulong)this.PendingEvents.Count + 1;
+
         this._pendingEvents.Add(e);
         return e;
     }

--- a/src/Neuroglia.Data/DomainEvent.cs
+++ b/src/Neuroglia.Data/DomainEvent.cs
@@ -19,11 +19,10 @@ namespace Neuroglia.Data;
 /// <summary>
 /// Represents the default implementation of the <see cref="IDomainEvent{TAggregate, TKey}"/> interface
 /// </summary>
-/// <typeparam name="TAggregate">The type of <see cref="IAggregateRoot"/> that has produced the <see cref="IDomainEvent"/></typeparam>
 /// <typeparam name="TKey">The type of key used to uniquely identify the <see cref="IAggregateRoot"/> that has produced the <see cref="IDomainEvent"/></typeparam>
-public abstract class DomainEvent<TAggregate, TKey>
-    : IDomainEvent<TAggregate, TKey>
-    where TAggregate : IAggregateRoot<TKey>
+[DataContract]
+public abstract class DomainEvent<TKey>
+    : IDomainEvent
     where TKey : IEquatable<TKey>
 {
 
@@ -38,20 +37,54 @@ public abstract class DomainEvent<TAggregate, TKey>
     /// <param name="aggregateId">The id of the <see cref="IAggregateRoot"/> that has produced the <see cref="IDomainEvent"/></param>
     protected DomainEvent(TKey aggregateId)
     {
-        this.AggregateId = aggregateId;
         this.CreatedAt = DateTimeOffset.Now;
+        this.AggregateId = aggregateId;
     }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember, JsonIgnore]
+    public abstract Type AggregateType { get; }
 
     /// <inheritdoc/>
     public virtual TKey AggregateId { get; protected set; } = default!;
 
-    object IDomainEvent.AggregateId => this.AggregateId;
+    /// <inheritdoc/>
+    [JsonInclude]
+    public virtual ulong AggregateVersion { get; internal protected set; }
+
+    /// <inheritdoc/>
+    [JsonInclude]
+    public virtual DateTimeOffset CreatedAt { get; protected set; }
+
+    object IDomainEvent.AggregateId => this.AggregateId!;
+
+}
+
+/// <summary>
+/// Represents the default implementation of the <see cref="IDomainEvent{TAggregate, TKey}"/> interface
+/// </summary>
+/// <typeparam name="TAggregate">The type of <see cref="IAggregateRoot"/> that has produced the <see cref="IDomainEvent"/></typeparam>
+/// <typeparam name="TKey">The type of key used to uniquely identify the <see cref="IAggregateRoot"/> that has produced the <see cref="IDomainEvent"/></typeparam>
+[DataContract]
+public abstract class DomainEvent<TAggregate, TKey>
+    : DomainEvent<TKey>, IDomainEvent<TAggregate, TKey>
+    where TAggregate : IAggregateRoot<TKey>
+    where TKey : IEquatable<TKey>
+{
+
+    /// <summary>
+    /// Initializes a new <see cref="DomainEvent{TAggregate, TKey}"/>
+    /// </summary>
+    protected DomainEvent() { }
+
+    /// <summary>
+    /// Initializes a new <see cref="DomainEvent{TAggregate, TKey}"/>
+    /// </summary>
+    /// <param name="aggregateId">The id of the <see cref="IAggregateRoot"/> that has produced the <see cref="IDomainEvent"/></param>
+    protected DomainEvent(TKey aggregateId) : base(aggregateId) { }
 
     /// <inheritdoc/>
     [IgnoreDataMember, JsonIgnore]
-    public virtual Type AggregateType => typeof(TAggregate);
-
-    /// <inheritdoc/>
-    public virtual DateTimeOffset CreatedAt { get; protected set; }
+    public override Type AggregateType => typeof(TAggregate);
 
 }

--- a/src/Neuroglia.Data/IDomainEvent.cs
+++ b/src/Neuroglia.Data/IDomainEvent.cs
@@ -30,6 +30,12 @@ public interface IDomainEvent
     object AggregateId { get; }
 
     /// <summary>
+    /// Gets the version of the source <see cref="IAggregateRoot"/>'s source after applying the <see cref="IDomainEvent"/>. 
+    /// In other words, indicates the position of the <see cref="IDomainEvent"/> in its source <see cref="IAggregateRoot"/>'s event stream
+    /// </summary>
+    ulong AggregateVersion { get; }
+
+    /// <summary>
     /// Gets the date and time the <see cref="IDomainEvent"/> has been created at
     /// </summary>
     DateTimeOffset CreatedAt { get; }
@@ -44,6 +50,7 @@ public interface IDomainEvent<TAggregate>
     : IDomainEvent
     where TAggregate : IAggregateRoot
 {
+
 
 
 }

--- a/src/Neuroglia.Integration/IIntegrationEvent.cs
+++ b/src/Neuroglia.Integration/IIntegrationEvent.cs
@@ -19,6 +19,19 @@ namespace Neuroglia;
 public interface IIntegrationEvent
 {
 
+    /// <summary>
+    /// Gets/sets the date and time at which the integration event has been created
+    /// </summary>
+    DateTimeOffset CreatedAt { get; }
 
+    /// <summary>
+    /// Gets/sets the id of the aggregate, if any, that has produced the event
+    /// </summary>
+    object? AggregateId { get; }
+
+    /// <summary>
+    /// Gets/sets the version of the event's source aggregate, if any, at the time it produced the event
+    /// </summary>
+    ulong? AggregateVersion { get; }
 
 }

--- a/src/Neuroglia.Integration/IntegrationEvent.cs
+++ b/src/Neuroglia.Integration/IntegrationEvent.cs
@@ -21,14 +21,19 @@ public abstract record IntegrationEvent
 {
 
     /// <summary>
+    /// Gets/sets the date and time at which the integration event has been produced
+    /// </summary>
+    public virtual DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
     /// Gets/sets the id of the aggregate, if any, that has produced the event
     /// </summary>
     public virtual object? AggregateId { get; set; }
 
     /// <summary>
-    /// Gets/sets the date and time at which the integration event has been produced
+    /// Gets/sets the version of the aggregate, if any, that has produced the event
     /// </summary>
-    public virtual DateTimeOffset CreatedAt { get; set; }
+    public ulong? AggregateVersion { get; set; }
 
 }
 

--- a/test/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
+++ b/test/Neuroglia.UnitTests/Cases/Serialization/JsonSerializerTests.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using Neuroglia.Serialization.Json;
+using Neuroglia.UnitTests.Data.Events;
 
 namespace Neuroglia.UnitTests.Cases.Serialization;
 


### PR DESCRIPTION
- Fixes the IDomainEvent interface and implementation to include an AggregateVersion property
- Fixes the AggregateRoot class to version registered IDomainEvents
- Fixes the CloudEventMiddleware to ignore request with empty content types