### PR TITLE
Fixed the CloudEventSpecVersion by encapsulating version elements into sub static classes, in order to expose version schema url

### DIFF
--- a/src/Neuroglia..Eventing.CloudEvents/CloudEvent.cs
+++ b/src/Neuroglia..Eventing.CloudEvents/CloudEvent.cs
@@ -35,11 +35,11 @@ public record CloudEvent
     public virtual string Id { get; set; } = null!;
 
     /// <summary>
-    /// Gets/sets the version of the CloudEvents specification which the event uses. Defaults to <see cref="CloudEventSpecVersion.v1"/>
+    /// Gets/sets the version of the CloudEvents specification which the event uses. Defaults to <see cref="CloudEventSpecVersion.V1.Version"/>
     /// </summary>
-    [DefaultValue(CloudEventSpecVersion.v1)]
+    [DefaultValue(CloudEventSpecVersion.V1.Version)]
     [DataMember(Order = 2, Name = "specversion", IsRequired = true), JsonPropertyOrder(2), JsonPropertyName("specversion")]
-    public virtual string SpecVersion { get; set; } = CloudEventSpecVersion.v1;
+    public virtual string SpecVersion { get; set; } = CloudEventSpecVersion.V1.Version;
 
     /// <summary>
     /// Gets/sets the date and time at which the event has been produced

--- a/src/Neuroglia..Eventing.CloudEvents/CloudEventSpecVersion.cs
+++ b/src/Neuroglia..Eventing.CloudEvents/CloudEventSpecVersion.cs
@@ -20,8 +20,20 @@ public static class CloudEventSpecVersion
 {
 
     /// <summary>
-    /// Specifies version 1.0
+    /// Exposes information about the <see href="https://cloudevents.io/">Cloud Event spec</see> version 1.0
     /// </summary>
-    public const string v1 = "1.0";
+    public static class V1
+    {
+
+        /// <summary>
+        /// Gets the '1.0' version of the <see href="https://cloudevents.io/">Cloud Event spec</see>
+        /// </summary>
+        public const string Version = "1.0";
+        /// <summary>
+        /// Gets the <see cref="Uri"/> that references the JSON Schema of the <see href="https://cloudevents.io/">Cloud Event spec</see> version 1.0
+        /// </summary>
+        public static readonly Uri SchemaUri = new("https://raw.githubusercontent.com/cloudevents/spec/v1.0.1/spec.json");
+
+    }
 
 }

--- a/src/Neuroglia.Data.Schemas.Json/Configuration/JsonSchemaReferenceOptions.cs
+++ b/src/Neuroglia.Data.Schemas.Json/Configuration/JsonSchemaReferenceOptions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Data.Schemas.Json.Configuration;
+
+/// <summary>
+/// Represents the options used to configure references to external <see cref="JsonSchema"/>s to load
+/// </summary>
+public class JsonSchemaReferenceOptions
+{
+
+    /// <summary>
+    /// Gets/sets the <see cref="System.Uri"/> used to reference the <see cref="JsonSchema"/> to load
+    /// </summary>
+    [Required]
+    public virtual Uri Uri { get; set; } = null!;
+
+    /// <summary>
+    /// Gets/sets a list containing functions, if any, used to mutate the external <see cref="JsonSchema"/> before registration
+    /// </summary>
+    public virtual List<Func<IServiceProvider, JsonSchema, Task<JsonSchema>>>? Mutators { get; set; }
+
+}

--- a/src/Neuroglia.Data.Schemas.Json/Configuration/JsonSchemaRegistryOptions.cs
+++ b/src/Neuroglia.Data.Schemas.Json/Configuration/JsonSchemaRegistryOptions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Data.Schemas.Json.Configuration;
+
+/// <summary>
+/// Represents the options used to configure an <see cref="IJsonSchemaRegistry"/>
+/// </summary>
+public class JsonSchemaRegistryOptions
+{
+
+    /// <summary>
+    /// Gets/sets a list containg options used to configure references to external <see cref="JsonSchema"/>s to load
+    /// </summary>
+    public virtual List<JsonSchemaReferenceOptions>? References { get; set; }
+
+}

--- a/src/Neuroglia.Data.Schemas.Json/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Schemas.Json/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Neuroglia.Data.Schemas.Json.Configuration;
+
+namespace Neuroglia.Data.Schemas.Json;
+
+/// <summary>
+/// Defines extensions for <see cref="IServiceCollection"/>s
+/// </summary>
+public static class IServiceCollectionExtensions
+{
+
+    /// <summary>
+    /// Adds and configures a new <see cref="JsonSchemaResolver"/>
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure</param>
+    /// <returns>The configured <see cref="IServiceCollection"/></returns>
+    public static IServiceCollection AddJsonSchemaResolver(this IServiceCollection services)
+    {
+        services.AddHttpClient();
+        services.TryAddSingleton<IJsonSchemaResolver, JsonSchemaResolver>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds and configures a new <see cref="JsonSchemaRegistry"/>
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure</param>
+    /// <param name="configuration">An <see cref="Action{T}"/> used to configure the <see cref="JsonSchemaRegistryOptions"/> to use</param>
+    /// <returns>The configured <see cref="IServiceCollection"/></returns>
+    public static IServiceCollection AddJsonSchemaRegistry(this IServiceCollection services, Action<JsonSchemaRegistryOptions>? configuration = null)
+    {
+        services.AddJsonSchemaResolver();
+        if (configuration != null) services.Configure(configuration);
+        services.TryAddSingleton<JsonSchemaRegistry>();
+        services.TryAddSingleton<IJsonSchemaRegistry>(provider => provider.GetRequiredService<JsonSchemaRegistry>());
+        services.AddSingleton<IHostedService>(provider => provider.GetRequiredService<JsonSchemaRegistry>());
+        return services;
+    }
+
+}

--- a/src/Neuroglia.Data.Schemas.Json/Neuroglia.Data.Schemas.Json.csproj
+++ b/src/Neuroglia.Data.Schemas.Json/Neuroglia.Data.Schemas.Json.csproj
@@ -30,6 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net.Generation" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Neuroglia.Data.Schemas.Json/Services/Interfaces/IJsonSchemaRegistry.cs
+++ b/src/Neuroglia.Data.Schemas.Json/Services/Interfaces/IJsonSchemaRegistry.cs
@@ -1,0 +1,29 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neuroglia.Data.Schemas.Json;
+
+/// <summary>
+/// Defines the fundamentals of a service used to manage of loaded <see cref="JsonSchema"/>s
+/// </summary>
+public interface IJsonSchemaRegistry
+{
+
+    /// <summary>
+    /// Gets the loaded <see cref="JsonSchema"/> at the specified <see cref="Uri"/>
+    /// </summary>
+    /// <param name="uri">The <see cref="Uri"/> of the <see cref="JsonSchema"/> to get</param>
+    /// <returns>The loaded <see cref="JsonSchema"/> at the specified <see cref="Uri"/>, if any</returns>
+    JsonSchema? GetSchema(Uri uri);
+
+}

--- a/src/Neuroglia.Data.Schemas.Json/Services/JsonSchemaRegistry.cs
+++ b/src/Neuroglia.Data.Schemas.Json/Services/JsonSchemaRegistry.cs
@@ -1,0 +1,135 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Neuroglia.Data.Schemas.Json.Configuration;
+
+namespace Neuroglia.Data.Schemas.Json;
+
+/// <summary>
+/// Represents the default implementation of the <see cref="IJsonSchemaRegistry"/>
+/// </summary>
+public class JsonSchemaRegistry
+    : IHostedService, IJsonSchemaRegistry, IDisposable
+{
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new <see cref="JsonSchemaRegistry"/>
+    /// </summary>
+    /// <param name="serviceProvider">The current <see cref="IServiceProvider"/></param>
+    /// <param name="loggerFactory">The service used to create <see cref="ILogger"/>s</param>
+    /// <param name="options">The service used to access the current current <see cref="JsonSchemaRegistryOptions"/></param>
+    /// <param name="schemaResolver">The service used to manage <see cref="JsonSchema"/>s</param>
+    /// <param name="httpClientFactory">The service used to create <see cref="System.Net.Http.HttpClient"/>s</param>
+    public JsonSchemaRegistry(IServiceProvider serviceProvider, ILoggerFactory loggerFactory, IOptions<JsonSchemaRegistryOptions> options, IJsonSchemaResolver schemaResolver, IHttpClientFactory httpClientFactory)
+    {
+        this.ServiceProvider = serviceProvider;
+        this.Logger = loggerFactory.CreateLogger(GetType());
+        this.Options = options.Value;
+        this.SchemaResolver = schemaResolver;
+        this.HttpClient = httpClientFactory.CreateClient();
+    }
+
+    /// <summary>
+    /// Gets the current <see cref="IServiceProvider"/>
+    /// </summary>
+    protected IServiceProvider ServiceProvider { get; }
+
+    /// <summary>
+    /// Gets the service used to perform logging
+    /// </summary>
+    protected ILogger Logger { get; }
+
+    /// <summary>
+    /// Gets the current <see cref="JsonSchemaRegistryOptions"/>
+    /// </summary>
+    protected JsonSchemaRegistryOptions Options { get; }
+
+    /// <summary>
+    /// Gets the service used to resolve <see cref="JsonSchema"/>s
+    /// </summary>
+    protected IJsonSchemaResolver SchemaResolver { get; }
+
+    /// <summary>
+    /// Gets the service used to perform HTTP requests
+    /// </summary>
+    protected HttpClient HttpClient { get; private set; }
+
+    /// <summary>
+    /// Gets the <see cref="JsonSchemaRegistry"/>'s <see cref="System.Threading.CancellationTokenSource"/>
+    /// </summary>
+    protected CancellationTokenSource CancellationTokenSource { get; private set; } = null!;
+
+    /// <inheritdoc/>
+    public virtual async Task StartAsync(CancellationToken cancellationToken)
+    {
+        this.CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (this.Options.References == null || this.Options.References.Count == 0) return;
+        foreach (var reference in this.Options.References)
+        {
+            try
+            {
+                var json = await this.HttpClient.GetStringAsync(reference.Uri, cancellationToken).ConfigureAwait(false);
+                var schema = await this.SchemaResolver.ResolveSchemaAsync(JsonSchema.FromText(json), cancellationToken).ConfigureAwait(false);
+                if(reference.Mutators != null && reference.Mutators.Count != 0)
+                {
+                    foreach (var mutator in reference.Mutators)
+                    {
+                        schema = await mutator(this.ServiceProvider, schema).ConfigureAwait(false);
+                    }
+                }
+                SchemaRegistry.Global.Register(reference.Uri, schema);
+            }
+            catch (Exception ex)
+            {
+                this.Logger.LogError("An error occured while retrieving the JSON Schema at '{uri}': {ex}", reference, ex);
+            }
+        }
+        this.HttpClient.Dispose();
+        this.HttpClient = null!;
+    }
+
+    /// <inheritdoc/>
+    public virtual Task StopAsync(CancellationToken cancellationToken) => Task.Run(() => this.CancellationTokenSource?.Cancel(), cancellationToken);
+
+    /// <inheritdoc/>
+    public virtual JsonSchema? GetSchema(Uri uri) => (JsonSchema?)SchemaRegistry.Global.Get(uri);
+
+    /// <summary>
+    /// Disposes of the <see cref="JsonSchemaRegistry"/>
+    /// </summary>
+    /// <param name="disposing">A boolean indicating whether or not the <see cref="JsonSchemaRegistry"/> has been disposed of</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!this._disposed)
+        {
+            if (disposing)
+            {
+                this.CancellationTokenSource?.Dispose();
+                this.HttpClient?.Dispose();
+            }
+            this._disposed = true;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+}


### PR DESCRIPTION
* Fixes the CloudEventSpecVersion by encapsulating version elements into sub static classes, in order to expose version schema url
* Adds a new IJsonSchemaRegistry interface and its default implementation