### PR TITLE
Renamed IServiceCollectionExtensions in multiple projects, to avoid having to use assembly aliases when reflection on a specific extension class

### DIFF
--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.EventStore/Extensions/EventStoreServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.EventStore/Extensions/EventStoreServiceCollectionExtensions.cs
@@ -14,23 +14,23 @@
 using Microsoft.Extensions.DependencyInjection;
 using Neuroglia.Data.Infrastructure.EventSourcing.Services;
 
-namespace Neuroglia.Data.Infrastructure.EventSourcing.Redis;
+namespace Neuroglia.Data.Infrastructure.EventSourcing;
 
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class EventStoreServiceCollectionExtensions
 {
 
     /// <summary>
-    /// Adds and configures a <see cref="RedisEventStore"/>
+    /// Adds and configures a <see cref="ESEventStore"/>
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure</param>
-    /// <param name="setup">An <see cref="Action{T}"/> used to configure the <see cref="RedisEventStore"/></param>
+    /// <param name="setup">An <see cref="Action{T}"/> used to configure the <see cref="ESEventStore"/></param>
     /// <returns>The configured <see cref="IServiceCollection"/></returns>
-    public static IServiceCollection AddRedisEventStore(this IServiceCollection services, Action<IEventStoreOptionsBuilder>? setup = null)
+    public static IServiceCollection AddESEventStore(this IServiceCollection services, Action<IEventStoreOptionsBuilder>? setup = null)
     {
-        services.AddEventStore<RedisEventStore>(setup);
+        services.AddEventStore<ESEventStore>(setup);
         return services;
     }
 

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Memory/Extensions/MemoryServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Memory/Extensions/MemoryServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Neuroglia.Data.Infrastructure.EventSourcing.Memory;
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class MemoryServiceCollectionExtensions
 {
 
     /// <summary>

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Redis/Extensions/RedisServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Redis/Extensions/RedisServiceCollectionExtensions.cs
@@ -14,23 +14,23 @@
 using Microsoft.Extensions.DependencyInjection;
 using Neuroglia.Data.Infrastructure.EventSourcing.Services;
 
-namespace Neuroglia.Data.Infrastructure.EventSourcing;
+namespace Neuroglia.Data.Infrastructure.EventSourcing.Redis;
 
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class RedisServiceCollectionExtensions
 {
 
     /// <summary>
-    /// Adds and configures a <see cref="ESEventStore"/>
+    /// Adds and configures a <see cref="RedisEventStore"/>
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure</param>
-    /// <param name="setup">An <see cref="Action{T}"/> used to configure the <see cref="ESEventStore"/></param>
+    /// <param name="setup">An <see cref="Action{T}"/> used to configure the <see cref="RedisEventStore"/></param>
     /// <returns>The configured <see cref="IServiceCollection"/></returns>
-    public static IServiceCollection AddESEventStore(this IServiceCollection services, Action<IEventStoreOptionsBuilder>? setup = null)
+    public static IServiceCollection AddRedisEventStore(this IServiceCollection services, Action<IEventStoreOptionsBuilder>? setup = null)
     {
-        services.AddEventStore<ESEventStore>(setup);
+        services.AddEventStore<RedisEventStore>(setup);
         return services;
     }
 

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing/Extensions/EventSourcingServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing/Extensions/EventSourcingServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Neuroglia.Data.Infrastructure.EventSourcing;
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class EventSourcingServiceCollectionExtensions
 {
 
     /// <summary>

--- a/src/Neuroglia.Data.Infrastructure.Memory/Extensions/MemoryServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.Memory/Extensions/MemoryServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace Neuroglia.Data.Infrastructure;
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class MemoryServiceCollectionExtensions
 {
 
     /// <summary>

--- a/src/Neuroglia.Data.Infrastructure.Mongo/Extensions/MongoServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.Mongo/Extensions/MongoServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Neuroglia.Data.Infrastructure;
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class MongoServiceCollectionExtensions
 {
 
     /// <summary>

--- a/src/Neuroglia.Data.Infrastructure.ObjectStorage.Minio/Extensions/MinioServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Data.Infrastructure.ObjectStorage.Minio/Extensions/MinioServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace Neuroglia.Data.Infrastructure.ObjectStorage;
 /// <summary>
 /// Defines extensions for <see cref="IServiceCollection"/>s
 /// </summary>
-public static class IServiceCollectionExtensions
+public static class MinioServiceCollectionExtensions
 {
 
     /// <summary>


### PR DESCRIPTION
Renames IServiceCollectionExtensions in multiple projects, to avoid having to use assembly aliases when reflection on a specific extension class