### PR TITLE
Replaced the name of the global variable holding the input data in the Javascript expression evaluator

### DIFF
--- a/src/Neuroglia.Data.Expressions.JavaScript/JavaScriptExpressionEvaluator.cs
+++ b/src/Neuroglia.Data.Expressions.JavaScript/JavaScriptExpressionEvaluator.cs
@@ -128,7 +128,7 @@ public class JavaScriptExpressionEvaluator
                         })
                     ;
                 }); ;
-            jsEngine.SetValue("input", data);
+            jsEngine.SetValue("$", data);
             if (args != null) foreach (var arg in args) jsEngine.SetValue(arg.Key, arg.Value);
             var result = jsEngine.Evaluate(expression).UnwrapIfPromise().ToObject();
             if (expectedType == typeof(object)) return result;

--- a/test/Neuroglia.UnitTests/Assets/string-concat.expression.js.txt
+++ b/test/Neuroglia.UnitTests/Assets/string-concat.expression.js.txt
@@ -1,1 +1,1 @@
-﻿input.foo + " " + input.bar
+﻿$.foo + " " + $.bar

--- a/test/Neuroglia.UnitTests/Assets/string-interpolation.expression.js.txt
+++ b/test/Neuroglia.UnitTests/Assets/string-interpolation.expression.js.txt
@@ -1,1 +1,1 @@
-﻿`${input.foo.bar} is a greeting`
+﻿`${$.foo.bar} is a greeting`

--- a/test/Neuroglia.UnitTests/Assets/string-quoted.expression.js.txt
+++ b/test/Neuroglia.UnitTests/Assets/string-quoted.expression.js.txt
@@ -1,1 +1,1 @@
-﻿`${input.foo} is "bar"`
+﻿`${$.foo} is "bar"`

--- a/test/Neuroglia.UnitTests/Assets/string-substitution.expression.js.txt
+++ b/test/Neuroglia.UnitTests/Assets/string-substitution.expression.js.txt
@@ -1,1 +1,1 @@
-﻿input.say.replace('${greeting}', input.someGreeting)
+﻿$.say.replace('${greeting}', $.someGreeting)

--- a/test/Neuroglia.UnitTests/Cases/Data/Expressions/Evaluators/JavaScriptExpressionEvaluatorTests.cs
+++ b/test/Neuroglia.UnitTests/Cases/Data/Expressions/Evaluators/JavaScriptExpressionEvaluatorTests.cs
@@ -53,7 +53,7 @@ public class JavaScriptExpressionEvaluatorTests
     {
         //arrange
         var value = 42;
-        var expression = "input.value";
+        var expression = "$.value";
         var data = new { value };
 
         //act
@@ -64,11 +64,25 @@ public class JavaScriptExpressionEvaluatorTests
     }
 
     [Fact]
-    public async Task Evaluate_ComplexTypeOutput_ShouldWork()
+    public async Task Evaluate_PrimitiveInput_ShouldWork()
+    {
+        //arrange
+        var expression = "$";
+        var data = 42;
+
+        //act
+        var result = (int)(await this.ExpressionEvaluator.EvaluateAsync<double>(expression, data));
+
+        //assert
+        result.Should().Be(data);
+    }
+
+    [Fact]
+    public async Task Evaluate_ObjectTypeOutput_ShouldWork()
     {
         //arrange
         var value = 42;
-        var expression = "${ input }";
+        var expression = "$";
         var data = new { value };
 
         //act
@@ -84,7 +98,7 @@ public class JavaScriptExpressionEvaluatorTests
         //arrange
         var bar = "bar";
         var baz = new { foo = "bar" };
-        var obj = new { foo = "${ input.bar }", bar = "foo", baz };
+        var obj = new { foo = "${ $.bar }", bar = "foo", baz };
         var data = new { bar };
         var expectedResult = new { foo = bar, bar = "foo", baz = baz.ToExpandoObject() };
 
@@ -100,7 +114,7 @@ public class JavaScriptExpressionEvaluatorTests
     {
         //arrange
         var data = JsonSerializer.Default.Deserialize<List<object>>(File.ReadAllText(Path.Combine("Assets", "dogs.json")))!;
-        var expression = "input.filter(i => i.category?.name === CONST.category)[0]";
+        var expression = "$.filter(i => i.category?.name === CONST.category)[0]";
         var args = new Dictionary<string, object>() { { "CONST", new { category = "Pugal" } } };
 
         //act
@@ -130,10 +144,9 @@ public class JavaScriptExpressionEvaluatorTests
         //arrange
         var data = new { };
         var expression = File.ReadAllText(Path.Combine("Assets", "pets.expression.js.txt"));
-        var args = new Dictionary<string, object>() { { "CONST", new { category = "Pugal" } } };
 
         //act
-        dynamic? result = await this.ExpressionEvaluator.EvaluateAsync(expression, data, args);
+        dynamic? result = await this.ExpressionEvaluator.EvaluateAsync(expression, data);
 
         //assert
         Assert.NotEmpty(result?.pets);
@@ -145,7 +158,7 @@ public class JavaScriptExpressionEvaluatorTests
         //arrange
         var json = File.ReadAllText(Path.Combine("Assets", "inputWithEscapedJson.json"));
         var data = Newtonsoft.Json.JsonConvert.DeserializeObject<ExpandoObject>(json)!;
-        var expression = "input._user";
+        var expression = "$._user";
 
         //act
         dynamic? result = await this.ExpressionEvaluator.EvaluateAsync(expression, data);


### PR DESCRIPTION
The name previously chosen to hold the data passed to a expression, `input`, was too generic and might easily lead to collision with provided arguments. Therefore, it's been replaced by a less common symbol: `$`. This basically allows the arguments dictionary to contain an entry with the `input` key without colliding with the data.

Given the following input data:
```json
{
   "foo": "bar",
   "answer": 42,
}
```

And the expected output:
`The Answer to the Ultimate Question of Life, the Universe, and Everything is 42, and foo = bar`

Previously, the expression would have been:
`"The Answer to the Ultimate Question of Life, the Universe, and Everything is " + input.answer + ", and foo = " + input.foo`

And now is:
`"The Answer to the Ultimate Question of Life, the Universe, and Everything is " + $.answer + ", and foo = " + $.foo`

Alternatives providing the same output:
- using interpolation: `` `The Answer to the Ultimate Question of Life, the Universe, and Everything is ${ $.answer }, and foo = ${ $.foo }` ``
- wrapping the expression in ${}: `${ "The Answer to the Ultimate Question of Life, the Universe, and Everything is " + $.answer + ", and foo = " + $.foo }`
- interpolation + wrapping the expression in ${}: ``${ `The Answer to the Ultimate Question of Life, the Universe, and Everything is ${ $.answer }, and foo = ${ $.foo }` }``

