### PR TITLE
Bubbling "child added" event so parents can update their own nodes/clusters in Blazor.Dagre

### DIFF
--- a/src/Neuroglia.Blazor.Dagre/Models/ClusterViewModel.cs
+++ b/src/Neuroglia.Blazor.Dagre/Models/ClusterViewModel.cs
@@ -66,6 +66,7 @@ public class ClusterViewModel
             child.Changed += OnChildChanged;
             if (child is IClusterViewModel cluster)
             {
+                cluster.ChildAdded += this.OnChildAdded;
                 this._allClusters.Add(cluster.Id, cluster);
                 this.Flatten(cluster);
             }
@@ -106,12 +107,29 @@ public class ClusterViewModel
         this.ChildAdded?.Invoke(this, node);
         if (node is IClusterViewModel cluster)
         {
+            cluster.ChildAdded += this.OnChildAdded;
             this._allClusters.Add(cluster.Id, cluster);
             this.Flatten(cluster);
             return;
         }
         this._allNodes.Add(node.Id, node);
         this.OnChange();
+    }
+
+    /// <inheritdoc/>
+    public virtual void OnChildAdded(object? sender, INodeViewModel child)
+    {
+        if (child is IClusterViewModel cluster)
+        {
+            this._allClusters.Add(cluster.Id, cluster);
+            this.Flatten(cluster);
+        }
+        else if (child is INodeViewModel node)
+        {
+            this._allNodes.Add(node.Id, node);
+        }
+        this.OnChange();
+        this.ChildAdded?.Invoke(this, child);
     }
 
     /// <summary>

--- a/src/Neuroglia.Blazor.Dagre/Models/GraphViewModel.cs
+++ b/src/Neuroglia.Blazor.Dagre/Models/GraphViewModel.cs
@@ -429,7 +429,6 @@ public class GraphViewModel
         if (this.Wheel != null) await this.Wheel.Invoke(new(e, sender, element));
     }
 
-    /// <inheritdoc/>
     public virtual void OnChildAdded(object? sender, INodeViewModel child)
     {
         if (child is IClusterViewModel cluster)


### PR DESCRIPTION
If a cluster containing a list of node is added to a parent cluster, the parent can update its own list of (all)nodes to include the ones of the child cluster.
But, before this fix, if the cluster was added to its parent before its nodes were appended, then the parent wouldn't be notified of the existence of the said nodes, making them 'unreachable'. 