### PR TITLE
Fixed graph centering in Blazor.Dagre

### DIFF
--- a/src/Neuroglia.Blazor.Dagre/wwwroot/neuroglia-blazor-dagre-interop.js
+++ b/src/Neuroglia.Blazor.Dagre/wwwroot/neuroglia-blazor-dagre-interop.js
@@ -38,8 +38,8 @@
         const svgBounds = graphElement.getBoundingClientRect();
         const graphBounds = graphElement.getBBox();
         return {
-            x: ((svgBounds.width - graphBounds.width) / 2) - Math.min(graphBounds.x, 0),
-            y: ((svgBounds.height - graphBounds.height) / 2) - Math.min(graphBounds.y, 0)
+            x: ((svgBounds.width - graphBounds.width) / 2),
+            y: ((svgBounds.height - graphBounds.height) / 2)
         };
     }
     window.neuroglia.blazor.getScale = (graphElement) => {


### PR DESCRIPTION
Resolved a minor issue in the graph centering algorithm where clicking twice caused a slight offset. This PR ensures the graph remains properly centered.