### PR TITLE
feat(Solution): Add NET8 support (In an addition to existing NET9)

### DIFF
--- a/samples/CamelCaseTextTransformPlugin/CamelCaseTextTransformPlugin.csproj
+++ b/samples/CamelCaseTextTransformPlugin/CamelCaseTextTransformPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/KebabCaseTextTransformPlugin/KebabCaseTextTransformPlugin.csproj
+++ b/samples/KebabCaseTextTransformPlugin/KebabCaseTextTransformPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/PluginBasedConsoleApp/PluginBasedConsoleApp.csproj
+++ b/samples/PluginBasedConsoleApp/PluginBasedConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Shared/Shared.csproj
+++ b/samples/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/SnakeCaseTextTransformPlugin/SnakeCaseTextTransformPlugin.csproj
+++ b/samples/SnakeCaseTextTransformPlugin/SnakeCaseTextTransformPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Neuroglia..Eventing.CloudEvents/Neuroglia.Eventing.CloudEvents.csproj
+++ b/src/Neuroglia..Eventing.CloudEvents/Neuroglia.Eventing.CloudEvents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Blazor.Dagre/Neuroglia.Blazor.Dagre.csproj
+++ b/src/Neuroglia.Blazor.Dagre/Neuroglia.Blazor.Dagre.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Neuroglia SPRL</Company>
     <Copyright>Copyright © 2024 Neuroglia SPRL. All rights reserved.</Copyright>
@@ -43,8 +43,11 @@
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 	
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworks)' == 'net9.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworks)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.12" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/Neuroglia.Core/Neuroglia.Core.csproj
+++ b/src/Neuroglia.Core/Neuroglia.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Expressions.Abstractions/Neuroglia.Data.Expressions.Abstractions.csproj
+++ b/src/Neuroglia.Data.Expressions.Abstractions/Neuroglia.Data.Expressions.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.csproj
+++ b/src/Neuroglia.Data.Expressions.JQ/Neuroglia.Data.Expressions.JQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -27,7 +27,7 @@
       <PackagePath>\</PackagePath>
       <Pack>True</Pack>
     </None>
-	<None Update="README.md">
+	<None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/Neuroglia.Data.Expressions.JavaScript/Neuroglia.Data.Expressions.JavaScript.csproj
+++ b/src/Neuroglia.Data.Expressions.JavaScript/Neuroglia.Data.Expressions.JavaScript.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -27,7 +27,7 @@
       <PackagePath>\</PackagePath>
       <Pack>True</Pack>
     </None>
-	<None Update="README.md">
+	<None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/Neuroglia.Data.Guards/Neuroglia.Data.Guards.csproj
+++ b/src/Neuroglia.Data.Guards/Neuroglia.Data.Guards.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.Abstractions/Neuroglia.Data.Infrastructure.Abstractions.csproj
+++ b/src/Neuroglia.Data.Infrastructure.Abstractions/Neuroglia.Data.Infrastructure.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions.csproj
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions/Neuroglia.Data.Infrastructure.EventSourcing.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.EventStore/Neuroglia.Data.Infrastructure.EventSourcing.EventStore.csproj
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.EventStore/Neuroglia.Data.Infrastructure.EventSourcing.EventStore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Memory/Neuroglia.Data.Infrastructure.EventSourcing.Memory.csproj
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Memory/Neuroglia.Data.Infrastructure.EventSourcing.Memory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing.Redis/Neuroglia.Data.Infrastructure.EventSourcing.Redis.csproj
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing.Redis/Neuroglia.Data.Infrastructure.EventSourcing.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.EventSourcing/Neuroglia.Data.Infrastructure.EventSourcing.csproj
+++ b/src/Neuroglia.Data.Infrastructure.EventSourcing/Neuroglia.Data.Infrastructure.EventSourcing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.Memory/Neuroglia.Data.Infrastructure.Memory.csproj
+++ b/src/Neuroglia.Data.Infrastructure.Memory/Neuroglia.Data.Infrastructure.Memory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Memory", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Infrastructure.Mongo/Neuroglia.Data.Infrastructure.Mongo.csproj
+++ b/src/Neuroglia.Data.Infrastructure.Mongo/Neuroglia.Data.Infrastructure.Mongo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.ObjectStorage.Abstractions/Neuroglia.Data.Infrastructure.ObjectStorage.Abstractions.csproj
+++ b/src/Neuroglia.Data.Infrastructure.ObjectStorage.Abstractions/Neuroglia.Data.Infrastructure.ObjectStorage.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Infrastructure.ObjectStorage.Minio/Neuroglia.Data.Infrastructure.ObjectStorage.Minio.csproj
+++ b/src/Neuroglia.Data.Infrastructure.ObjectStorage.Minio/Neuroglia.Data.Infrastructure.ObjectStorage.Minio.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.Redis/Neuroglia.Data.Infrastructure.Redis.csproj
+++ b/src/Neuroglia.Data.Infrastructure.Redis/Neuroglia.Data.Infrastructure.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.ResourceOriented.Abstractions/Neuroglia.Data.Infrastructure.ResourceOriented.Abstractions.csproj
+++ b/src/Neuroglia.Data.Infrastructure.ResourceOriented.Abstractions/Neuroglia.Data.Infrastructure.ResourceOriented.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Infrastructure.ResourceOriented.Redis/Neuroglia.Data.Infrastructure.ResourceOriented.Redis.csproj
+++ b/src/Neuroglia.Data.Infrastructure.ResourceOriented.Redis/Neuroglia.Data.Infrastructure.ResourceOriented.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.Infrastructure.ResourceOriented/Neuroglia.Data.Infrastructure.ResourceOriented.csproj
+++ b/src/Neuroglia.Data.Infrastructure.ResourceOriented/Neuroglia.Data.Infrastructure.ResourceOriented.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data.PatchModel/Neuroglia.Data.PatchModel.csproj
+++ b/src/Neuroglia.Data.PatchModel/Neuroglia.Data.PatchModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Patching", ""))</RootNamespace>

--- a/src/Neuroglia.Data.Schemas.Json/Neuroglia.Data.Schemas.Json.csproj
+++ b/src/Neuroglia.Data.Schemas.Json/Neuroglia.Data.Schemas.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Data/Neuroglia.Data.csproj
+++ b/src/Neuroglia.Data/Neuroglia.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<Company>Neuroglia SRL</Company>

--- a/src/Neuroglia.Eventing.CloudEvents.AspNetCore/Neuroglia.Eventing.CloudEvents.AspNetCore.csproj
+++ b/src/Neuroglia.Eventing.CloudEvents.AspNetCore/Neuroglia.Eventing.CloudEvents.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Library</OutputType>

--- a/src/Neuroglia.Eventing.CloudEvents.Infrastructure.Abstractions/Neuroglia.Eventing.CloudEvents.Infrastructure.Abstractions.csproj
+++ b/src/Neuroglia.Eventing.CloudEvents.Infrastructure.Abstractions/Neuroglia.Eventing.CloudEvents.Infrastructure.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Eventing.CloudEvents.Infrastructure/Neuroglia.Eventing.CloudEvents.Infrastructure.csproj
+++ b/src/Neuroglia.Eventing.CloudEvents.Infrastructure/Neuroglia.Eventing.CloudEvents.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Integration/Neuroglia.Integration.csproj
+++ b/src/Neuroglia.Integration/Neuroglia.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Integration", ""))</RootNamespace>

--- a/src/Neuroglia.Mapping/Neuroglia.Mapping.csproj
+++ b/src/Neuroglia.Mapping/Neuroglia.Mapping.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net9.0</TargetFramework>
+	<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Measurements/Neuroglia.Measurements.csproj
+++ b/src/Neuroglia.Measurements/Neuroglia.Measurements.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Mediation.Abstractions/Neuroglia.Mediation.Abstractions.csproj
+++ b/src/Neuroglia.Mediation.Abstractions/Neuroglia.Mediation.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Mediation.AspNetCore/Neuroglia.Mediation.AspNetCore.csproj
+++ b/src/Neuroglia.Mediation.AspNetCore/Neuroglia.Mediation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>

--- a/src/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
+++ b/src/Neuroglia.Mediation.FluentValidation/Neuroglia.Mediation.FluentValidation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  	<TargetFramework>net9.0</TargetFramework>
+  	<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   	<ImplicitUsings>enable</ImplicitUsings>
   	<Nullable>enable</Nullable>
   	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Mediation/Neuroglia.Mediation.csproj
+++ b/src/Neuroglia.Mediation/Neuroglia.Mediation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Plugins.Abstractions/Neuroglia.Plugins.Abstractions.csproj
+++ b/src/Neuroglia.Plugins.Abstractions/Neuroglia.Plugins.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Plugins/Neuroglia.Plugins.csproj
+++ b/src/Neuroglia.Plugins/Neuroglia.Plugins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Reactive/Neuroglia.Reactive.csproj
+++ b/src/Neuroglia.Reactive/Neuroglia.Reactive.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Scripting.Abstractions/Neuroglia.Scripting.Abstractions.csproj
+++ b/src/Neuroglia.Scripting.Abstractions/Neuroglia.Scripting.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Scripting.NodeJS/Neuroglia.Scripting.NodeJS.csproj
+++ b/src/Neuroglia.Scripting.NodeJS/Neuroglia.Scripting.NodeJS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Scripting.Python/Neuroglia.Scripting.Python.csproj
+++ b/src/Neuroglia.Scripting.Python/Neuroglia.Scripting.Python.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Security.Abstractions/Neuroglia.Security.Abstractions.csproj
+++ b/src/Neuroglia.Security.Abstractions/Neuroglia.Security.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions", ""))</RootNamespace>

--- a/src/Neuroglia.Security.AspNetCore/Neuroglia.Security.AspNetCore.csproj
+++ b/src/Neuroglia.Security.AspNetCore/Neuroglia.Security.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Library</OutputType>

--- a/src/Neuroglia.Serialization.Abstractions/Neuroglia.Serialization.csproj
+++ b/src/Neuroglia.Serialization.Abstractions/Neuroglia.Serialization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Serialization.DataContract/Neuroglia.Serialization.DataContract.csproj
+++ b/src/Neuroglia.Serialization.DataContract/Neuroglia.Serialization.DataContract.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Serialization.NewtonsoftJson/Neuroglia.Serialization.NewtonsoftJson.csproj
+++ b/src/Neuroglia.Serialization.NewtonsoftJson/Neuroglia.Serialization.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Serialization.ProtobufNet/Neuroglia.Serialization.ProtobufNet.csproj
+++ b/src/Neuroglia.Serialization.ProtobufNet/Neuroglia.Serialization.ProtobufNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Serialization.Xml/Neuroglia.Serialization.Xml.csproj
+++ b/src/Neuroglia.Serialization.Xml/Neuroglia.Serialization.Xml.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Neuroglia.Serialization.YamlDotNet/Neuroglia.Serialization.YamlDotNet.csproj
+++ b/src/Neuroglia.Serialization.YamlDotNet/Neuroglia.Serialization.YamlDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/test/Neuroglia.UnitTests/Neuroglia.UnitTests.csproj
+++ b/test/Neuroglia.UnitTests/Neuroglia.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request aims to support both currently supported by Microsoft .NET versions.

Tests on the main and current branches don't look stable to me, so I had about 7-11 tests failed locally (Win11).
Hope it will help to add support of .NET 8 for https://github.com/neuroglia-io/asyncapi.

If I did something wrong, please leave a comment, I will be happy to fix it if necessary.