### PR TITLE
Fixed centering computation error in Blazor.Dagre

### DIFF
--- a/src/Neuroglia.Blazor.Dagre/DagreGraph.razor
+++ b/src/Neuroglia.Blazor.Dagre/DagreGraph.razor
@@ -305,7 +305,7 @@
     {
         if (this.graph == null) 
             return;
-        var position = await this.JSRuntime.InvokeAsync<BoundingBox>("neuroglia.blazor.getCenter", this.graphReference);
+        var position = await this.JSRuntime.InvokeAsync<BoundingBox>("neuroglia.blazor.getCenter", this.graph.Scale, this.graphReference);
         this.graph.X = position.X;
         this.graph.Y = position.Y;
         this.isDirty = true;
@@ -315,7 +315,7 @@
     {
         if (this.graph == null)
             return;
-        var position = await this.JSRuntime.InvokeAsync<BoundingBox>("neuroglia.blazor.getCenter", this.graphReference, node);
+        var position = await this.JSRuntime.InvokeAsync<BoundingBox>("neuroglia.blazor.getCenter", this.graph.Scale, this.graphReference, node);
         this.graph.X = position.X;
         this.graph.Y = position.Y;
         this.isDirty = true;

--- a/src/Neuroglia.Blazor.Dagre/wwwroot/neuroglia-blazor-dagre-interop.js
+++ b/src/Neuroglia.Blazor.Dagre/wwwroot/neuroglia-blazor-dagre-interop.js
@@ -34,19 +34,23 @@
     window.neuroglia.blazor.preventScroll = (graphElement) => {
         graphElement.addEventListener("wheel", e => e.preventDefault(), { passive: false });
     }
-    window.neuroglia.blazor.getCenter = (graphElement, node) => {
-        const scale = window.neuroglia.blazor.getScale(graphElement);
+    window.neuroglia.blazor.getCenter = (scale, graphElement, node) => {
         const svgBounds = graphElement.getBoundingClientRect();
         const graphBounds = graphElement.getBBox();
-        const center = {
-            x: (((svgBounds.width / scale) - graphBounds.width) / 2),
-            y: (((svgBounds.height / scale) - graphBounds.height) / 2)
+        let center = {
+            x: (((svgBounds.width) - graphBounds.width) / 2),
+            y: (((svgBounds.height) - graphBounds.height) / 2)
         };
-        if (!node) return center;
+        if (node) {
+            center = {
+                x: center.x + ((graphBounds.width / 2) - (node.x * scale)),
+                y: center.y + ((graphBounds.height / 2) - (node.y * scale)),
+            };
+        }
         return {
-            x: center.x + ((graphBounds.width / 2) - node.x),
-            y: center.y + ((graphBounds.height / 2) - node.y),
-        };
+            x: center.x / scale,
+            y: center.y / scale
+        }
     }
     window.neuroglia.blazor.getScale = (graphElement) => {
         const svgBounds = graphElement.getBoundingClientRect();


### PR DESCRIPTION
Fixed an error in the centering computation where the wrong scaling variable was used and some internal measurements were not properly scaled with the said variate.