### PR TITLE
Fix the registration of serialization services to make sure not to add already added services

### DIFF
--- a/src/Neuroglia.Data.Infrastructure.Memory/Services/MemoryCacheRepository.cs
+++ b/src/Neuroglia.Data.Infrastructure.Memory/Services/MemoryCacheRepository.cs
@@ -47,7 +47,10 @@ public class MemoryCacheRepository<TEntity, TKey>
         ArgumentNullException.ThrowIfNull(entity);
         var collectionKey = this.BuildCacheKey();
         var entityKey = this.BuildCacheKey(entity.Id);
-        if (this.Cache.TryGetValue(collectionKey, out List<string>? keys) && keys != null && keys.Contains(entityKey)) throw new Exception($"An entity with the specified id '{entity.Id}' already exists in the repository");
+        if (this.Cache.TryGetValue(collectionKey, out List<string>? keys) && keys != null)
+        {
+            if (keys.Contains(entityKey)) throw new Exception($"An entity with the specified id '{entity.Id}' already exists in the repository");
+        }
         else keys = [];
         keys.Add(entityKey);
         this.Cache.Set(collectionKey, keys);

--- a/src/Neuroglia.Serialization.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Serialization.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ public static class IServiceCollectionExtensions
         where TSerializer : class, ISerializer
     {
         services.TryAdd(new ServiceDescriptor(typeof(TSerializer), typeof(TSerializer), lifetime));
-        services.TryAdd(new ServiceDescriptor(typeof(ISerializer), typeof(TSerializer), lifetime));
+        if (!services.Any(s => s.ServiceType == typeof(ISerializer) && s.ImplementationType == typeof(TSerializer))) services.Add(new ServiceDescriptor(typeof(ISerializer), typeof(TSerializer), lifetime));
         return services;
     }
 

--- a/src/Neuroglia.Serialization.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Neuroglia.Serialization.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ public static class IServiceCollectionExtensions
         where TSerializer : class, ISerializer
     {
         services.TryAdd(new ServiceDescriptor(typeof(TSerializer), typeof(TSerializer), lifetime));
-        services.Add(new ServiceDescriptor(typeof(ISerializer), typeof(TSerializer), lifetime));
+        services.TryAdd(new ServiceDescriptor(typeof(ISerializer), typeof(TSerializer), lifetime));
         return services;
     }
 
@@ -63,7 +63,7 @@ public static class IServiceCollectionExtensions
         setup ??= JsonSerializer.DefaultOptionsConfiguration!;
         services.Configure(setup);
         services.AddSerializer<JsonSerializer>(lifetime);
-        services.Add(new ServiceDescriptor(typeof(IJsonSerializer), typeof(JsonSerializer), lifetime));
+        services.TryAdd(new ServiceDescriptor(typeof(IJsonSerializer), typeof(JsonSerializer), lifetime));
         return services;
     }
 


### PR DESCRIPTION
- Fixes the registration of serialization services to make sure not to add already added services
- Fixes the `MemoryCacheRepository` which was incorrectly reinitializing the key list upon adding a new entity