### PR TITLE
Fixed the `UserInfo` by turning the `Claims` property into a list of `ClaimInfo` instances, thus supporting multi-valued claims

### DIFF
--- a/src/Neuroglia.Security.Abstractions/ClaimInfo.cs
+++ b/src/Neuroglia.Security.Abstractions/ClaimInfo.cs
@@ -1,0 +1,41 @@
+﻿// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Neuroglia.Security;
+
+/// <summary>
+/// Represents the description of a claim.
+/// </summary>
+[DataContract]
+public record ClaimInfo
+{
+
+    /// <summary>
+    /// Gets or sets the claim's type.
+    /// </summary>
+    [Required, MinLength(1)]
+    [DataMember(Order = 1, Name = "type", IsRequired = true), JsonPropertyOrder(1), JsonPropertyName("type")]
+    public virtual required string Type { get; init; }
+
+    /// <summary>
+    /// Gets or sets the claim's value.
+    /// </summary>
+    [Required, MinLength(1)]
+    [DataMember(Order = 2, Name = "value", IsRequired = true), JsonPropertyOrder(2), JsonPropertyName("value")]
+    public virtual required string Value { get; init; }
+
+}

--- a/src/Neuroglia.Security.Abstractions/Services/UserInfoProvider.cs
+++ b/src/Neuroglia.Security.Abstractions/Services/UserInfoProvider.cs
@@ -36,7 +36,11 @@ public class UserInfoProvider(IUserAccessor userAccessor)
     public virtual UserInfo? GetCurrentUser()
     {
         if (UserAccessor.User == null || UserAccessor.User.Identity?.IsAuthenticated != true) return null;
-        return new(UserAccessor.User.Identity.Name!, UserAccessor.User.Identity.AuthenticationType!, UserAccessor.User.Claims.ToDictionary(c => c.Type, c => c.Value));
+        return new(UserAccessor.User.Identity.Name!, UserAccessor.User.Identity.AuthenticationType!, UserAccessor.User.Claims.Select(c => new ClaimInfo()
+        {
+            Type = c.Type,
+            Value = c.Value
+        }));
     }
 
 }

--- a/src/Neuroglia.Security.Abstractions/UserInfo.cs
+++ b/src/Neuroglia.Security.Abstractions/UserInfo.cs
@@ -35,13 +35,13 @@ public record UserInfo
     /// <param name="name">The name of the user to describe</param>
     /// <param name="authenticationType">The name of the mechanism used to authenticate the user</param>
     /// <param name="claims">A key/comma-separated values mapping of the claims used to describe the authenticated user</param>
-    public UserInfo(string name, string authenticationType, IDictionary<string, string>? claims = null)
+    public UserInfo(string name, string authenticationType, IEnumerable<ClaimInfo>? claims = null)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
         if (string.IsNullOrWhiteSpace(authenticationType)) throw new ArgumentNullException(nameof(authenticationType));
         this.Name = name;
         this.AuthenticationType = authenticationType;
-        this.Claims = claims;
+        this.Claims = claims?.ToList();
     }
 
     /// <summary>
@@ -49,20 +49,20 @@ public record UserInfo
     /// </summary>
     [Required]
     [DataMember(Order = 1, Name = "name", IsRequired = true), JsonPropertyOrder(1), JsonPropertyName("name")]
-    public virtual string Name { get; set; } = null!;
+    public virtual string Name { get; init; } = null!;
 
     /// <summary>
     /// Gets/sets the name of the mechanism used to authenticate the user
     /// </summary>
     [Required]
     [DataMember(Order = 2, Name = "authenticationType", IsRequired = true), JsonPropertyOrder(2), JsonPropertyName("authenticationType")]
-    public virtual string AuthenticationType { get; set; } = null!;
+    public virtual string AuthenticationType { get; init; } = null!;
 
     /// <summary>
     /// Gets/sets a key/comma-separated values mapping of the claims used to describe the authenticated user
     /// </summary>
     [DataMember(Order = 3, Name = "claims", IsRequired = true), JsonPropertyOrder(3), JsonPropertyName("claims")]
-    public virtual IDictionary<string, string>? Claims { get; set; }
+    public virtual IReadOnlyList<ClaimInfo>? Claims { get; init; }
 
     /// <inheritdoc/>
     public override string ToString() => this.Name;


### PR DESCRIPTION
Fixes the `UserInfo` by turning the `Claims` property into a list of `ClaimInfo` instances, thus supporting multi-valued claims